### PR TITLE
Fix certmanager in epinioserver issue

### DIFF
--- a/chart/epinio-installer/Chart.yaml
+++ b/chart/epinio-installer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: epinio-installer
-version: 0.3.1
+version: 0.3.2
 # This is the version of the epinio/installer image
 appVersion: v0.0.1-15
 description: Deploys Epinio and dependencies automatically

--- a/chart/epinio-installer/templates/NOTES.txt
+++ b/chart/epinio-installer/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 {{- if .Values.domain }}
 You can get the IP address of your Ingress controller by passing this command:
-`kubectl describe svc traefik --namespace traefik | grep Ingress | awk '{print $3}'`
+`kubectl describe svc traefik --namespace traefik | awk '/Ingress/ { print $3 }'`
 
 Make sure your domain points to the IP address of your Ingress controller (1.2.3.4).
 {{ end }}

--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -144,6 +144,8 @@ stringData:
             value: "{{ $sessionKey }}"
           - name: "server.accessControlAllowOrigin"
             value: {{ default "*" .Values.accessControlAllowOrigin | quote }}
+          - name: "server.tlsIssuer"
+            value: "{{ .Values.tlsIssuer }}"
           - name: "server.timeoutMultiplier"
             value: "1"
           - name: "server.traceLevel"


### PR DESCRIPTION
with `tlsIssuer=letsencrypt-production` I have this error:
```
🕞  Running staging
  🚢 Streaming application logs
  Namespace: workspace
  Application: apps-683638986
  2021/12/14 13:31:27 EpinioApiClient "msg"="response is not StatusOK" "error"="Internal Server Error: PipelineRun tekton-staging parameters is missing some parameters required by Pipeline e952ea181c2bd450's parameters: PipelineRun missing parameters: [REGISTRY_CERTIFICATE_SECRET REGISTRY_CERTIFICATE_HASH]" "status"=500
```

After some debugging I found that the `epinio-server` deployment had the wrong `TLS_ISSUER` value:
```
# k get certificate epinio -n epinio -o yaml
[...]
spec:
  dnsNames:
  - epinio.ldevulder-gke.epinio-ci.suse.dev
  issuerRef:
    kind: ClusterIssuer
    name: epinio-ca
  secretName: epinio-tls
```
But the `epinio-registry` was OK:
```
# k get certificate -n epinio-registry epinio-registry -o yaml
[...]
spec:
  dnsNames:
  - epinio-registry.ldevulder-gke.epinio-ci.suse.dev
  issuerRef:
    kind: ClusterIssuer
    name: letsencrypt-production
  secretName: epinio-registry-tls
  secretTemplate:
    annotations:
      kubed.appscode.com/sync: kubed-registry-tls-from=epinio-registry
```

In fact the `tlsIssuer` value of `epinio-installer` chart is not passed to `epinio`, this PR should fix this.