### PR TITLE
Make image repository configurable in the epinio chart

### DIFF
--- a/chart/epinio/templates/_helpers.tpl
+++ b/chart/epinio/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "registry-url" -}}
+{{- if .Values.registryURL -}}
+{{ trimSuffix "/" .Values.registryURL }}/
+{{- end -}}
+{{- end -}}

--- a/chart/epinio/templates/_helpers.tpl
+++ b/chart/epinio/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "registry-url" -}}
+{{- if .Values.registryURL -}}
+{{- printf "%s/" .Values.registryURL -}}
+{{- end -}}
+{{- end -}}

--- a/chart/epinio/templates/_helpers.tpl
+++ b/chart/epinio/templates/_helpers.tpl
@@ -1,5 +1,0 @@
-{{- define "registry-url" -}}
-{{- if .Values.registryURL -}}
-{{- printf "%s/" .Values.registryURL -}}
-{{- end -}}
-{{- end -}}

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -238,7 +238,7 @@ spec:
             - name: REGISTRY_CERTIFICATE_SECRET
               value: "{{ .Values.registry.certificateSecret }}"
             {{- end }}
-          image: "{{ template "registry-url" }}{{ .Values.image.epinio.repository}}:{{ or .Values.image.epinio.tag .Chart.AppVersion }}"
+          image: "{{ template "registry-url" . }}{{ .Values.image.epinio.repository}}:{{ or .Values.image.epinio.tag .Chart.AppVersion }}"
           livenessProbe:
             httpGet:
               path: /ready

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -238,7 +238,7 @@ spec:
             - name: REGISTRY_CERTIFICATE_SECRET
               value: "{{ .Values.registry.certificateSecret }}"
             {{- end }}
-          image: splatform/epinio-server:{{ .Chart.AppVersion }}
+          image: "{{ template "registry-url" . }}{{ .Values.server.containerImage }}:{{ .Chart.AppVersion }}"
           livenessProbe:
             httpGet:
               path: /ready

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -238,7 +238,7 @@ spec:
             - name: REGISTRY_CERTIFICATE_SECRET
               value: "{{ .Values.registry.certificateSecret }}"
             {{- end }}
-          image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.epinio.repository}}:{{ or .Values.image.epinio.tag .Chart.AppVersion }}"
+          image: "{{ template "registry-url" }}{{ .Values.image.epinio.repository}}:{{ or .Values.image.epinio.tag .Chart.AppVersion }}"
           livenessProbe:
             httpGet:
               path: /ready

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -238,7 +238,7 @@ spec:
             - name: REGISTRY_CERTIFICATE_SECRET
               value: "{{ .Values.registry.certificateSecret }}"
             {{- end }}
-          image: "{{ template "registry-url" . }}{{ .Values.server.containerImage }}:{{ .Chart.AppVersion }}"
+          image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.epinio.repository}}:{{ or .Values.image.epinio.tag .Chart.AppVersion }}"
           livenessProbe:
             httpGet:
               path: /ready

--- a/chart/epinio/templates/tekton-buildpacks-task.yaml
+++ b/chart/epinio/templates/tekton-buildpacks-task.yaml
@@ -79,7 +79,7 @@ spec:
 
   steps:
     - name: prepare
-      image: "{{ template "registry-url" }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
+      image: "{{ template "registry-url" . }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
       args:
         - "--env-vars"
         - "$(params.ENV_VARS[*])"
@@ -165,7 +165,7 @@ spec:
         runAsGroup: 1000
 
     - name: results
-      image: "{{ template "registry-url" }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
+      image: "{{ template "registry-url" . }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
       script: |
         #!/usr/bin/env bash
         set -e

--- a/chart/epinio/templates/tekton-buildpacks-task.yaml
+++ b/chart/epinio/templates/tekton-buildpacks-task.yaml
@@ -79,7 +79,7 @@ spec:
 
   steps:
     - name: prepare
-      image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
+      image: "{{ template "registry-url" }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
       args:
         - "--env-vars"
         - "$(params.ENV_VARS[*])"
@@ -165,7 +165,7 @@ spec:
         runAsGroup: 1000
 
     - name: results
-      image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
+      image: "{{ template "registry-url" }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
       script: |
         #!/usr/bin/env bash
         set -e

--- a/chart/epinio/templates/tekton-buildpacks-task.yaml
+++ b/chart/epinio/templates/tekton-buildpacks-task.yaml
@@ -79,7 +79,7 @@ spec:
 
   steps:
     - name: prepare
-      image: "{{ template "registry-url" . }}{{ .Values.tekton.bashImage}}"
+      image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
       args:
         - "--env-vars"
         - "$(params.ENV_VARS[*])"
@@ -165,7 +165,7 @@ spec:
         runAsGroup: 1000
 
     - name: results
-      image: "{{ template "registry-url" . }}{{ .Values.tekton.bashImage}}"
+      image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
       script: |
         #!/usr/bin/env bash
         set -e

--- a/chart/epinio/templates/tekton-buildpacks-task.yaml
+++ b/chart/epinio/templates/tekton-buildpacks-task.yaml
@@ -79,7 +79,7 @@ spec:
 
   steps:
     - name: prepare
-      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      image: "{{ template "registry-url" . }}{{ .Values.tekton.bashImage}}"
       args:
         - "--env-vars"
         - "$(params.ENV_VARS[*])"
@@ -165,7 +165,7 @@ spec:
         runAsGroup: 1000
 
     - name: results
-      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      image: "{{ template "registry-url" . }}{{ .Values.tekton.bashImage}}"
       script: |
         #!/usr/bin/env bash
         set -e

--- a/chart/epinio/templates/tekton-stage-pipeline.yaml
+++ b/chart/epinio/templates/tekton-stage-pipeline.yaml
@@ -106,7 +106,7 @@ spec:
   - name: source
   steps:
   - name: cleanup
-    image: "{{ template "registry-url" . }}{{ .Values.tekton.kubectlImage }}"
+    image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
     workingDir: "/workspace/source"
     command:
       - sh
@@ -126,7 +126,7 @@ spec:
   - name: source
   steps:
   - name: extract
-    image: "{{ template "registry-url" . }}{{ .Values.tekton.kubectlImage }}"
+    image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
     workingDir: "/workspace/source"
     command:
       - sh

--- a/chart/epinio/templates/tekton-stage-pipeline.yaml
+++ b/chart/epinio/templates/tekton-stage-pipeline.yaml
@@ -106,7 +106,7 @@ spec:
   - name: source
   steps:
   - name: cleanup
-    image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
+    image: "{{ template "registry-url" }}{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
     workingDir: "/workspace/source"
     command:
       - sh
@@ -126,7 +126,7 @@ spec:
   - name: source
   steps:
   - name: extract
-    image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
+    image: "{{ template "registry-url" }}{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
     workingDir: "/workspace/source"
     command:
       - sh

--- a/chart/epinio/templates/tekton-stage-pipeline.yaml
+++ b/chart/epinio/templates/tekton-stage-pipeline.yaml
@@ -106,7 +106,7 @@ spec:
   - name: source
   steps:
   - name: cleanup
-    image: "{{ template "registry-url" }}{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
+    image: "{{ template "registry-url" . }}{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
     workingDir: "/workspace/source"
     command:
       - sh
@@ -126,7 +126,7 @@ spec:
   - name: source
   steps:
   - name: extract
-    image: "{{ template "registry-url" }}{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
+    image: "{{ template "registry-url" . }}{{ .Values.image.kubectl.repository}}:{{ .Values.image.kubectl.tag }}"
     workingDir: "/workspace/source"
     command:
       - sh

--- a/chart/epinio/templates/tekton-stage-pipeline.yaml
+++ b/chart/epinio/templates/tekton-stage-pipeline.yaml
@@ -106,7 +106,7 @@ spec:
   - name: source
   steps:
   - name: cleanup
-    image: lachlanevenson/k8s-kubectl:v1.22.2
+    image: "{{ template "registry-url" . }}{{ .Values.tekton.kubectlImage }}"
     workingDir: "/workspace/source"
     command:
       - sh
@@ -126,7 +126,7 @@ spec:
   - name: source
   steps:
   - name: extract
-    image: lachlanevenson/k8s-kubectl:v1.22.2
+    image: "{{ template "registry-url" . }}{{ .Values.tekton.kubectlImage }}"
     workingDir: "/workspace/source"
     command:
       - sh

--- a/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
+++ b/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
@@ -35,7 +35,7 @@ spec:
       default: ["help"]
   steps:
     - name: awscli
-      image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
+      image: "{{ template "registry-url" }}{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
       script: "$(params.SCRIPT)"
       args:
         - "$(params.ARGS)"

--- a/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
+++ b/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
@@ -35,7 +35,7 @@ spec:
       default: ["help"]
   steps:
     - name: awscli
-      image: docker.io/amazon/aws-cli:2.0.52@sha256:1506cec98a7101c935176d440a14302ea528b8f92fcaf4a6f1ea2d7ecef7edc4 #tag: 2.0.52
+      image: "{{ template "registry-url" . }}{{ .Values.tekton.awsCliImage }}"
       script: "$(params.SCRIPT)"
       args:
         - "$(params.ARGS)"

--- a/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
+++ b/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
@@ -35,7 +35,7 @@ spec:
       default: ["help"]
   steps:
     - name: awscli
-      image: "{{ template "registry-url" . }}{{ .Values.tekton.awsCliImage }}"
+      image: "{{ trimSuffix "/" .Values.registryURL }}/{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
       script: "$(params.SCRIPT)"
       args:
         - "$(params.ARGS)"

--- a/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
+++ b/chart/epinio/templates/tekton-task-aws-cli-0.2.yaml
@@ -35,7 +35,7 @@ spec:
       default: ["help"]
   steps:
     - name: awscli
-      image: "{{ template "registry-url" }}{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
+      image: "{{ template "registry-url" . }}{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
       script: "$(params.SCRIPT)"
       args:
         - "$(params.ARGS)"

--- a/chart/epinio/values.schema.json
+++ b/chart/epinio/values.schema.json
@@ -6,18 +6,52 @@
     "registryURL": {
       "type": "string"
     },
-    "tekton": {
-      "description": "tekton configuration",
+    "image": {
       "type": "object",
       "properties": {
-        "bashImage": {
-          "type": "string"
+        "epinio": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
         },
-        "kubectlImage": {
-          "type": "string"
+        "bash": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
         },
-        "awsCliImage": {
-          "type": "string"
+        "awscli": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "kubectl": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -41,9 +75,6 @@
           "type": "integer"
         },
         "registryCertificateSecret": {
-          "type": "string"
-        },
-        "containerImage": {
           "type": "string"
         }
       }

--- a/chart/epinio/values.schema.json
+++ b/chart/epinio/values.schema.json
@@ -3,6 +3,24 @@
   "title": "Values",
   "type": "object",
   "properties": {
+    "registryURL": {
+      "type": "string"
+    },
+    "tekton": {
+      "description": "tekton configuration",
+      "type": "object",
+      "properties": {
+        "bashImage": {
+          "type": "string"
+        },
+        "kubectlImage": {
+          "type": "string"
+        },
+        "awsCliImage": {
+          "type": "string"
+        }
+      }
+    },
     "server": {
       "description": "server configuration",
       "type": "object",
@@ -23,6 +41,9 @@
           "type": "integer"
         },
         "registryCertificateSecret": {
+          "type": "string"
+        },
+        "containerImage": {
           "type": "string"
         }
       }

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -5,8 +5,18 @@
 # The email address you are planning to use for getting notifications about your certificates.
 email: "epinio@suse.com"
 
+# The URL of the container registry from where to pull container images
+# for the various created Pods. Don't confuse this registry with the "Epinio
+# registry" which is the one where Epinio stores the application images.
+registryURL: ""
+
 # The system domain that will be used to access the epinio API server
 systemDomain: ""
+
+tekton:
+  bashImage: "bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6"
+  kubectlImage: "lachlanevenson/k8s-kubectl:v1.22.2"
+  awsCliImage: "amazon/aws-cli:2.0.52@sha256:1506cec98a7101c935176d440a14302ea528b8f92fcaf4a6f1ea2d7ecef7edc4" #tag: 2.0.52
 
 server:
   # Domain which serves the Rancher UI (to access the API)
@@ -24,6 +34,10 @@ server:
 
   # Increase this value to instruct the API server to produce more debug output
   traceLevel: 0
+
+  # The epinio server image. Combinded with the top-level "registryURL", it
+  # allows the use of a private registry.
+  containerImage: "splatform/epinio-server"
 
 certManagerNamespace: ""
 

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -13,10 +13,19 @@ registryURL: ""
 # The system domain that will be used to access the epinio API server
 systemDomain: ""
 
-tekton:
-  bashImage: "bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6"
-  kubectlImage: "lachlanevenson/k8s-kubectl:v1.22.2"
-  awsCliImage: "amazon/aws-cli:2.0.52@sha256:1506cec98a7101c935176d440a14302ea528b8f92fcaf4a6f1ea2d7ecef7edc4" #tag: 2.0.52
+image:
+  epinio:
+    repository: splatform/epinio-server
+    tag: ""
+  bash:
+    repository: library/bash
+    tag: 5.1.4
+  awscli:
+    repository: amazon/aws-cli
+    tag: 2.0.52
+  kubectl:
+    repository: lachlanevenson/k8s-kubectl
+    tag: v1.22.2
 
 server:
   # Domain which serves the Rancher UI (to access the API)
@@ -34,10 +43,6 @@ server:
 
   # Increase this value to instruct the API server to produce more debug output
   traceLevel: 0
-
-  # The epinio server image. Combinded with the top-level "registryURL", it
-  # allows the use of a private registry.
-  containerImage: "splatform/epinio-server"
 
 certManagerNamespace: ""
 


### PR DESCRIPTION
This way a private repository can be used for airgapped installations.
The builder image is still coming from dockerhub by default but at least
it can be specified in the application manifest or with as a "push"
argument.

Fixes: https://github.com/epinio/epinio/issues/979