### PR TITLE
When using external registry don't try to mount registry secret in tekton pod

### DIFF
--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -166,7 +166,7 @@ stringData:
 
           - name: "registry.url"
             value: {{ default (print "epinio-registry." .Values.domain)  .Values.externalRegistryURL | quote }}
-          {{- if (not .Values.externalRegistryURL) }}
+          {{- if not .Values.externalRegistryURL }}
           - name: "registry.localhostURL"
             value: "127.0.0.1:30500"
           {{- end }}

--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -174,10 +174,12 @@ stringData:
             value: "{{ $registryPassword }}"
           - name: "registry.namespace"
             value: {{ default "apps" .Values.externalRegistryNamespace | quote }}
+          {{- if not .Values.externalRegistryURL }}
           - name: "registry.certificateSecret"
             value: "epinio-registry-tls"
           - name: "registry.certificateSecretNamespace"
             value: "epinio-registry"
+          {{- end }}
           - name: "server.forceKubeInternalRegistryTLS"
             value: {{ default "false" .Values.forceKubeInternalRegistryTLS | quote }}
         preDeploy:

--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -166,8 +166,10 @@ stringData:
 
           - name: "registry.url"
             value: {{ default (print "epinio-registry." .Values.domain)  .Values.externalRegistryURL | quote }}
+          {{- if (not .Values.externalRegistryURL) }}
           - name: "registry.localhostURL"
             value: "127.0.0.1:30500"
+          {{- end }}
           - name: "registry.username"
             value: "{{ $registryUsername }}"
           - name: "registry.password"

--- a/chart/epinio-installer/values.yaml
+++ b/chart/epinio-installer/values.yaml
@@ -40,13 +40,13 @@ domain: "localhost.omg.howdoi.website"
 # s3UseSSL: ""
 
 # If you are using your own external registry, set the following options:
-# --external-registry-url: ""
-# --external-registry-username: ""
-# --external-registry-password: ""
+# externalRegistryURL: ""
+# externalRegistryUsername: ""
+# externalRegistryPassword: ""
 
 # Optional
 # Provide namespace (or organization) of the external registry to which you have push access. It can be left empty.
-# --external-registry-namespace: ""
+# externalRegistryNamespace: ""
 
 # Use TLS when application images will be pulled by kubernetes. Only applies to the internal registry. (default "false")
 # --force-kube-internal-registry-tls: ""

--- a/chart/epinio/templates/registry-secret.yaml
+++ b/chart/epinio/templates/registry-secret.yaml
@@ -15,7 +15,7 @@ stringData:
           "auth":"{{ printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc }}",
           "username":"{{ .Values.registry.username }}",
           "password":"{{ .Values.registry.password }}"
-        } {{- if .Values.registry.localhostURL }} ,
+        } {{- if .Values.registry.localhostURL and (not .Values.registry.externalRegistryURL) }} ,
         "{{ .Values.registry.localhostURL }}": {
           "auth":"{{ printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc }}",
           "username":"{{ .Values.registry.username }}",

--- a/chart/epinio/templates/registry-secret.yaml
+++ b/chart/epinio/templates/registry-secret.yaml
@@ -15,7 +15,7 @@ stringData:
           "auth":"{{ printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc }}",
           "username":"{{ .Values.registry.username }}",
           "password":"{{ .Values.registry.password }}"
-        } {{- if .Values.registry.localhostURL and (not .Values.registry.externalRegistryURL) }} ,
+        } {{- if and .Values.registry.localhostURL (not .Values.registry.externalRegistryURL) }} ,
         "{{ .Values.registry.localhostURL }}": {
           "auth":"{{ printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc }}",
           "username":"{{ .Values.registry.username }}",


### PR DESCRIPTION
By setting the registry.certificateSecret to non empty value, the epinio
helm chart sets the REGISTRY_CERTIFICATE_SECRET environment variable on the
epinio server Deployment. This results in epinio server trying to mount
the secret on the tekton pod. In the case of external registry, that
secret doesn't exist.

https://github.com/epinio/epinio/blob/247ef0a8304ab130a8395d383570c73a65245722/internal/api/v1/application/stage.go#L190-L195
https://github.com/epinio/epinio/blob/247ef0a8304ab130a8395d383570c73a65245722/internal/api/v1/application/stage.go#L374-L379