### PR TITLE
Disable version check for linter

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -40,6 +40,7 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
+
       - name: Set up k3d cluster
         uses: nolar/setup-k3d-k3s@v1
         with:
@@ -49,3 +50,4 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --config ct/ct-install.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/ct/ct-install.yaml
+++ b/ct/ct-install.yaml
@@ -1,6 +1,7 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
 target-branch: main
+check-version-increment: false
 chart-dirs:
   - chart
 charts: chart/epinio-installer

--- a/ct/ct.yaml
+++ b/ct/ct.yaml
@@ -1,6 +1,7 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
 target-branch: main
+check-version-increment: false
 chart-dirs:
   - chart
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
We want to disable version check when we push a pull request. 
Anyway, this check is done later when we release charts with chart-releaser.