### PR TITLE
Add option to specify a custom TLS issuer

### DIFF
--- a/chart/epinio-installer/questions.yml
+++ b/chart/epinio-installer/questions.yml
@@ -6,9 +6,23 @@ questions:
   type: strings
   required: false
   group: "General settings"
+- variable: useCustomTlsIssuer
+  label: Use your own TLS issuer
+  default: "false"
+  description: "Use your own TLS issuer"
+  type: boolean
+  group: "General settings"
+  show_subquestion_if: true
+  subquestions:
+  - variable: customTlsIssuer
+    label: TLS issuer
+    description: "Name of the cluster issuer to use"
+    type: strings
+    required: false
 - variable: tlsIssuer
+  show_if: "useCustomTlsIssuer=false"
   label: TLS issuer
-  description: "Name of the cluster issue to use"
+  description: "Name of the predefined cluster issuer to use"
   default: "epinio-ca"
   type: enum
   required: false
@@ -42,17 +56,18 @@ questions:
   required: false
   group: "General settings"
 - variable: forceKubeInternalRegistryTLS
-  label: Force tls for internal registry
+  label: Force TLS for internal registry
   required: false
   type: boolean
   group: "General settings"
 - variable: skipCertManager
-  label: Skip Cert Manager installation
+  show_if: "useCustomTlsIssuer=false"
+  label: Use existing CertManager installation
   required: false
   type: boolean
   group: "General settings"
 - variable: skipLinkerd
-  label: Use existing Linkerd Installation
+  label: Use existing Linkerd installation
   required: false
   type: boolean
   group: "General settings"

--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -62,7 +62,7 @@ stringData:
           name: kubed
           path: assets/installer/kubed-v0.12.0.tgz
 
-      {{- if not .Values.skipCertManager }}
+      {{- if not (or .Values.skipCertManager .Values.useCustomTlsIssuer) }}
       - id: cert-manager
         namespace: cert-manager
         type: helm
@@ -145,7 +145,7 @@ stringData:
           - name: "server.accessControlAllowOrigin"
             value: {{ default "*" .Values.accessControlAllowOrigin | quote }}
           - name: "server.tlsIssuer"
-            value: "{{ .Values.tlsIssuer }}"
+            value: {{ default .Values.tlsIssuer .Values.customTlsIssuer | quote }}
           - name: "server.timeoutMultiplier"
             value: {{ .Values.server.timeoutMultiplier }}
           - name: "server.traceLevel"
@@ -209,7 +209,7 @@ stringData:
             type: annotation
 
       - id: registry
-        {{- if not .Values.skipCertManager }}
+        {{- if not (or .Values.skipCertManager .Values.useCustomTlsIssuer) }}
         needs: cert-manager
         {{- end }}
         namespace: epinio-registry
@@ -226,7 +226,7 @@ stringData:
           - name: createNodePort
             value: "true"
           - name: tlsIssuer
-            value: "{{ .Values.tlsIssuer }}"
+            value: {{ default .Values.tlsIssuer .Values.customTlsIssuer | quote }}
         preDeploy:
           - type: "pod"
             selector: "app.kubernetes.io/name=webhook"


### PR DESCRIPTION
This is mainly for Rancher, it already works in CLI.

Note: installation of cert-manager is skipped if `useCustomTlsIssuer` is used, as the issuer/CA needs to be configured before epinio installation.