### PR TITLE
Add epinio-installer manifest for updatecli

### DIFF
--- a/updatecli/updatecli.d/epinio-installer.yaml
+++ b/updatecli/updatecli.d/epinio-installer.yaml
@@ -1,0 +1,59 @@
+---
+title: "Bump epinio-installer version"
+# Define git repository configuration to know where to push changes
+scms:
+  helm-charts:
+    kind: "github"
+    spec:
+      user: "{{ .github.epinio.user }}"
+      email: "{{ .github.epinio.email }}"
+      owner: "{{ .github.epinio.owner }}"
+      repository: "{{ .github.epinio.repository }}"
+      token: '{{ requiredEnv .github.epinio.token }}'
+      username: "{{ .github.epinio.username }}"
+      branch: "{{ .github.epinio.branch }}"
+
+# Define pullrequest configuration if one needs to be created by updatecli
+pullrequests:
+  helm-charts:
+    kind: "github"
+    scmID: "helm-charts"
+    targets:
+      - "helm-charts"
+    spec:
+      labels:
+        - "dependencies"
+        - "epinio-installer"
+
+# Defines where we get source values
+sources:
+  epinio-installer:
+    name: "Get Latest epinio version"
+    kind: "githubRelease"
+    spec:
+      owner: "epinio"
+      repository: "installer"
+      username: '{{ requiredEnv .github.epinio.username }}'
+      token: '{{ requiredEnv .github.epinio.token }}'
+
+# Defines condition that must pass in order to update the epinio-installer helm chart
+conditions:
+  dockerImage:
+    name: 'Check that ghcr.io/epinio/epinio-installer:{{ source "epinio-installer" }} is published'
+    kind: "dockerImage"
+    sourceID: "epinio-installer"
+    spec:
+      image: "ghcr.io/epinio/epinio-installer"
+      username: '{{ requiredEnv .github.epinio.username }}'
+      password: '{{ requiredEnv .github.epinio.token }}'
+
+# Defines what needs to be udpated if needed
+targets:
+  helm-charts:
+    name: "Update epinio-installer version in chart epinio-installer"
+    kind: "yaml"
+    scmID: "helm-charts"
+    sourceID: "epinio-installer"
+    spec:
+      file: "chart/epinio-installer/Chart.yaml"
+      key: "appVersion"

--- a/updatecli/updatecli.d/epinio-installer.yaml
+++ b/updatecli/updatecli.d/epinio-installer.yaml
@@ -35,6 +35,12 @@ sources:
       repository: "installer"
       username: '{{ requiredEnv .github.epinio.username }}'
       token: '{{ requiredEnv .github.epinio.token }}'
+  epinioHelmChart:
+    name: "Get Latest epinio helm chart version"
+    kind: helmChart
+    spec:
+      url: https://epinio.github.io/helm-charts
+      name: epinio
 
 # Defines condition that must pass in order to update the epinio-installer helm chart
 conditions:
@@ -57,3 +63,12 @@ targets:
     spec:
       file: "chart/epinio-installer/Chart.yaml"
       key: "appVersion"
+  epinio-chart:
+    name: "Update epinio helm chart tgz url in chart epinio-installer"
+    kind: "yaml"
+    scmID: "helm-charts"
+    sourceID: "epinioHelmChart"
+    spec:
+      file: "chart/epinio-installer/values.yaml"
+      key: "epinioChart"
+      value: 'https://github.com/epinio/helm-charts/releases/download/epinio-{{ source "epinioHelmChart" }}/epinio-{{ source "epinioHelmChart" }}.tgz'

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -59,11 +59,9 @@ conditions:
 targets:
   helm-charts:
     name: "Update epinio version in chart epinio"
-    kind: "helmChart"
+    kind: "yaml"
     scmID: "helm-charts"
     sourceID: "epinio"
     spec:
-      appVersion: true
-      name: "chart/epinio"
-      file: "values.yaml"
-      key: "image.epinio.tag"
+      file: "chart/epinio/Chart.yaml"
+      key: "appVersion"


### PR DESCRIPTION
This pull request introduces the following update pipelines:

**Bump to latest installer version in chart Epinio**
Based on the latest epinio installer version, updatecli checks that the docker image `ghcr.io/epinio/epinio-installer:<latest_version>` exists. If it's the case then updatecli ensures that the current repository uses the latest Epinio installer version defined in the chart Epinio and automatically opens a pull request if it's not the case.

**Bump epinio chart version used in chart epinio-installer**
Based on the latest Epinio chart version, updatecli ensures that the helm chart "epinio-installer" has the variable "epinioChart" set to the latest URL containing the Epinio chart tgz  and automatically opens a pull request if it's not the case. 

**Update the pipeline that bump the epinio helm chart to the latest epinio server**
Based on discussion with the rest of the team, it appears that we don't want to let updatecli bumping Epinio chart version but just bumping a yaml file value. So I propose to switching from kind `helmChart` to `yaml`.

