### PR TITLE
Do not rotate minio access keys on re-install/upgrade of epinio

### DIFF
--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -5,14 +5,14 @@ metadata:
   name: manifest
 stringData:
   manifest.yaml: |
-    ---
     {{ $registryUsername := default "admin" .Values.externalRegistryUsername -}}
     {{- $registryPassword := default (randAlphaNum 10) .Values.externalRegistryPassword -}}
-    {{- $accessKey := randAlphaNum 16 -}}
-    {{- $secretKey := randAlphaNum 16 -}}
+    {{- $oldkeys := (lookup "v1" "Secret" "minio-epinio" "tenant-creds").data -}}
+    {{- $accessKey := empty $oldkeys | ternary (randAlphaNum 16) (b64dec (default "" $oldkeys.accesskey)) -}}
+    {{- $secretKey := empty $oldkeys | ternary (randAlphaNum 16) (b64dec (default "" $oldkeys.secretkey)) -}}
     {{- $sessionKey := randAlphaNum 24 -}}
-    {{- $password := randAlphaNum 12 -}}
-
+    {{- $password := randAlphaNum 12 }}
+    ---
     components:
       {{- if not .Values.skipLinkerd }}
       - id: linkerd


### PR DESCRIPTION
Should fix https://github.com/epinio/epinio/issues/1064

epinio PR using this repo as submodule: https://github.com/epinio/epinio/pull/1117
    
- On first install random keys are chosen, as before
- On second install
    - `lookup` is used to detect the existing minio secret holding the keys
    - the old keys are extracted (note: base64 decoding needed),
    - and fed into the manifest as the new keys,
    - effectively keeping them unchanged.
    
Notes:
  - `if`/`else` does have scoping issues with the variable, hence the use of `ternary`. I.e. the variable is either not defined later, or is not overwritten as desired.
    
  - helm/go templating is strict in the function arguments. Thus, while we use `empty` to control which value is returned by `ternary` we still have to protect the `b64dec` from nil/invalid input via `default` in the initial case, when `lookup` does not find anything.
    
 - Moved the variable definitions before `---` introducing the YAML section.  This enables us to emit debug output into the result without running into issues with the YAML parser, as it simply ignores everything before the `---`.

I.e. on install random access keys are chosen.
On upgrades these access keys are kept by reusing them for the new manifest

And below the text/code I used to debug the templating today. Placed after the last variable assignment, and before the `---` marker starting the actual yaml.
```
    ##
    ## old    = ({{ $oldkeys }})
    ## empty  = ({{ empty $oldkeys }})
    ## oldb64 = ({{ $oldkeys.accesskey }})
    ## oldacc = ({{ b64dec (default "" $oldkeys.accesskey) }})
    ## olda/K = ({{ kindOf $oldkeys.accesskey }})
    ## olda/T = ({{ typeOf $oldkeys.accesskey }})
    ## access = ({{ $accessKey }})
    ##
```



