### PR TITLE
AWS secret key must be password type

### DIFF
--- a/chart/epinio-installer/questions.yml
+++ b/chart/epinio-installer/questions.yml
@@ -113,7 +113,7 @@ questions:
   group: "External S3 storage"
   subquestions:
   - variable: s3Endpoint
-    label: S3 Endpoint
+    label: S3 endpoint
     description: "Endpoint of your S3 storage"
     type: strings
     required: false
@@ -125,10 +125,10 @@ questions:
   - variable: s3SecretAccessKey
     label: S3 access key secret
     description: "Secret access key to authenticate to your S3 storage"
-    type: strings
+    type: password
     required: false
   - variable: s3Bucket
-    label: S3 Bucket
+    label: S3 bucket
     description: "Bucket of your S3 storage"
     type: strings
     required: false


### PR DESCRIPTION
In the current state, the aws access key secret is printed in clear in the s3 tab.
Secret variables must always be set to password type.
This PR also fixes two labels where their labels are not consistent with others (useless uppercase).