### PR TITLE
Automate helm chart version update

### DIFF
--- a/updatecli/updatecli.d/epinio-installer.yaml
+++ b/updatecli/updatecli.d/epinio-installer.yaml
@@ -57,18 +57,22 @@ conditions:
 targets:
   helm-charts:
     name: "Update epinio-installer version in chart epinio-installer"
-    kind: "yaml"
+    kind: "helmChart"
     scmID: "helm-charts"
     sourceID: "epinio-installer"
     spec:
-      file: "chart/epinio-installer/Chart.yaml"
+      name: "chart/epinio-installer"
+      file: "Chart.yaml"
       key: "appVersion"
+      versionIncrement: minor
   epinio-chart:
     name: "Update epinio helm chart tgz url in chart epinio-installer"
-    kind: "yaml"
+    kind: "helmChart"
     scmID: "helm-charts"
     sourceID: "epinioHelmChart"
     spec:
-      file: "chart/epinio-installer/values.yaml"
+      name: "chart/epinio-installer"
+      file: "values.yaml"
       key: "epinioChart"
       value: 'https://github.com/epinio/helm-charts/releases/download/epinio-{{ source "epinioHelmChart" }}/epinio-{{ source "epinioHelmChart" }}.tgz'
+      versionIncrement: minor

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -59,9 +59,11 @@ conditions:
 targets:
   helm-charts:
     name: "Update epinio version in chart epinio"
-    kind: "yaml"
+    kind: "helmChart"
     scmID: "helm-charts"
     sourceID: "epinio"
     spec:
-      file: "chart/epinio/Chart.yaml"
+      name: "chart/epinio"
+      file: "Chart.yaml"
       key: "appVersion"
+      versionIncrement: minor


### PR DESCRIPTION
I propose to automate Helm chart version update from updatecli. 
Most of the time that would just reduce one step from the release process defined [here](https://github.com/epinio/epinio/blob/4c1988a4e4b510f6659b42469b34c009bcb7befe/docs/release.md), with fewer chances for mistake

Worst case, we can still change the version within the pull request generated by updatecli

So if we update the docker image used in epinio-installer or epinio helm chart then we automatically bump the minor version

Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>