### PR TITLE
Trim -noasset from epinio-installer release name

### DIFF
--- a/updatecli/updatecli.d/epinio-installer.yaml
+++ b/updatecli/updatecli.d/epinio-installer.yaml
@@ -35,6 +35,8 @@ sources:
       repository: "installer"
       username: '{{ requiredEnv .github.epinio.username }}'
       token: '{{ requiredEnv .github.epinio.token }}'
+    transformers:
+      - trimSuffix: "-noassets"
   epinioHelmChart:
     name: "Get Latest epinio helm chart version"
     kind: helmChart


### PR DESCRIPTION
It appears that the Epinio installer docker image tag doesn't have the string "-noassets" while the latest Github Release does.
Updatecli has the ability to "transform" a value as described on the documentation [transformers](https://www.updatecli.io/docs/core/transformer/) 
Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>