### PR TITLE
Remove updatecli for epinio-installer

### DIFF
--- a/updatecli/updatecli.d/epinio-installer.yaml
+++ b/updatecli/updatecli.d/epinio-installer.yaml
@@ -27,14 +27,6 @@ pullrequests:
 
 # Defines where we get source values
 sources:
-  epinio-installer:
-    name: "Get Latest epinio-installer version"
-    kind: "githubRelease"
-    spec:
-      owner: "epinio"
-      repository: "installer"
-      username: '{{ requiredEnv .github.epinio.username }}'
-      token: '{{ requiredEnv .github.epinio.token }}'
   epinioHelmChart:
     name: "Get Latest epinio helm chart version"
     kind: helmChart
@@ -42,29 +34,8 @@ sources:
       url: https://epinio.github.io/helm-charts
       name: epinio
 
-# Defines condition that must pass in order to update the epinio-installer helm chart
-conditions:
-  dockerImage:
-    name: 'Check that ghcr.io/epinio/epinio-installer:{{ source "epinio-installer" }} is published'
-    kind: "dockerImage"
-    sourceID: "epinio-installer"
-    spec:
-      image: "ghcr.io/epinio/epinio-installer"
-      username: '{{ requiredEnv .github.epinio.username }}'
-      password: '{{ requiredEnv .github.epinio.token }}'
-
 # Defines what needs to be udpated if needed
 targets:
-  helm-charts:
-    name: "Update epinio-installer version in chart epinio-installer"
-    kind: "helmChart"
-    scmID: "helm-charts"
-    sourceID: "epinio-installer"
-    spec:
-      name: "chart/epinio-installer"
-      file: "Chart.yaml"
-      key: "appVersion"
-      versionIncrement: minor
   epinio-chart:
     name: "Update epinio helm chart tgz url in chart epinio-installer"
     kind: "helmChart"


### PR DESCRIPTION
The epinio-installer helm chart doesn't depend on the epinio/installer repo's Github releases directly.

The container image is built by [Dockerfile-installer]. That always uses the latest epinio-installer-noassets image as a base. (Change manually before publishing if specific version is needed).
But we do expect 0.0.18-noassets to be the last version that we ever need, because we hope to switch to helm chart dependencies eventually.

Publishing is triggered manually via https://github.com/epinio/helm-charts/actions/workflows/release-installer.yml

Once a new image is published, the `appVersion` needs to be changed manually, like in https://github.com/epinio/helm-charts/pull/85/files