### PR TITLE
Ingress class name

### DIFF
--- a/chart/container-registry/templates/container-registry.yaml
+++ b/chart/container-registry/templates/container-registry.yaml
@@ -27,7 +27,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
   labels:
@@ -35,6 +34,7 @@ metadata:
   name: registry
   namespace: {{ .Release.Namespace }}
 spec:
+  ingressClassName: "traefik"
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/chart/container-registry/templates/container-registry.yaml
+++ b/chart/container-registry/templates/container-registry.yaml
@@ -34,7 +34,9 @@ metadata:
   name: registry
   namespace: {{ .Release.Namespace }}
 spec:
-  ingressClassName: "traefik"
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: "{{ .Values.ingress.ingressClassName }}"
+  {{- end }}
   rules:
   - host: {{ .Values.domain }}
     http:

--- a/chart/container-registry/values.yaml
+++ b/chart/container-registry/values.yaml
@@ -16,3 +16,7 @@ nginx:
 # secured registry because there is no way to add
 # registry CA to kubelet.
 createNodePort: true
+
+ingress:
+  # The ingressClassName is used to select the ingress controller. If empty no class will be added to the ingresses.
+  ingressClassName: ""

--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -125,6 +125,12 @@ stringData:
             value: {{ .Values.server.timeoutMultiplier }}
           - name: "server.traceLevel"
             value: "{{ .Values.server.traceLevel }}"
+          {{ if .Values.ingress.ingressClassName }}
+          - name: "server.ingressClassName"
+            value: "{{ .Values.ingress.ingressClassName }}"
+          - name: "ingress.ingressClassName"
+            value: "{{ .Values.ingress.ingressClassName }}"
+          {{ end }}
 
           - name: "minio.enabled"
             value: {{ .Values.minio.enabled }}
@@ -197,6 +203,10 @@ stringData:
             value: "true"
           - name: tlsIssuer
             value: {{ default .Values.tlsIssuer .Values.customTlsIssuer | quote }}
+          {{- if .Values.ingress.ingressClassName }}
+          - name: "ingress.ingressClassName"
+            value: "{{ .Values.ingress.ingressClassName }}"
+          {{-  end }}
         preDeploy:
           - type: "pod"
             selector: "app.kubernetes.io/name=webhook"

--- a/chart/epinio-installer/values.yaml
+++ b/chart/epinio-installer/values.yaml
@@ -11,6 +11,10 @@ email: "epinio@suse.com"
 # The name of the cluster issuer to use. Epinio creates three options: 'epinio-ca', 'letsencrypt-production', and 'selfsigned-issuer'. (default "epinio-ca")
 tlsIssuer: "epinio-ca"
 
+ingress:
+  # The ingressClassName is used to select the ingress controller. If empty no class will be added to the ingresses.
+  ingressClassName: ""
+
 # The domain you are planning to use for Epinio. Should be pointing to the traefik public IP (mandatory option).
 domain: "localhost.omg.howdoi.website"
 

--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -23,7 +23,9 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: traefik
+          {{- if .Values.ingress.ingressClassName }}
+          class: "{{ .Values.ingress.ingressClassName }}"
+          {{- end }}
           ingressTemplate:
             metadata:
               annotations:

--- a/chart/epinio/templates/ingress.yaml
+++ b/chart/epinio/templates/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
   labels:
@@ -10,6 +9,7 @@ metadata:
   name: epinio
   namespace: epinio
 spec:
+  ingressClassName: "traefik"
   rules:
   - host: "epinio.{{ .Values.domain }}"
     http:

--- a/chart/epinio/templates/ingress.yaml
+++ b/chart/epinio/templates/ingress.yaml
@@ -9,7 +9,9 @@ metadata:
   name: epinio
   namespace: epinio
 spec:
-  ingressClassName: "traefik"
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: "{{ .Values.ingress.ingressClassName }}"
+  {{- end }}
   rules:
   - host: "epinio.{{ .Values.domain }}"
     http:

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -255,6 +255,10 @@ spec:
             - name: REGISTRY_CERTIFICATE_SECRET
               value: "{{ .Values.registry.certificateSecret }}"
             {{- end }}
+            {{- if .Values.ingress.ingressClassName }}
+            - name: INGRESS_CLASS_NAME
+              value: "{{ .Values.ingress.ingressClassName }}"
+            {{- end }}
           image: "{{ template "registry-url" . }}{{ .Values.image.epinio.repository}}:{{ or .Values.image.epinio.tag .Chart.AppVersion }}"
           livenessProbe:
             httpGet:

--- a/chart/epinio/values.schema.json
+++ b/chart/epinio/values.schema.json
@@ -76,7 +76,15 @@
         },
         "registryCertificateSecret": {
           "type": "string"
+        },
+        "ingressClassName": {
+          "type": "string"
         }
+      }
+    },
+    "ingress": {
+      "ingressClassName": {
+        "type": "string"
       }
     },
     "s3": {

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -35,6 +35,13 @@ server:
   tlsIssuer: "epinio-ca"
   # Increase this value to instruct the API server to produce more debug output
   traceLevel: 0
+  # The ingressClassName is used to select the ingress controller for apps. If empty no class will be added to their ingresseses.
+  ingressClassName: ""
+
+ingress:
+  # The ingressClassName is used to select the ingress controller for the server. If empty no class will be added to the ingresses.
+  ingressClassName: ""
+
 certManagerNamespace: ""
 
 


### PR DESCRIPTION
Use the [ingressClassName](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) when creating ingresses.

This also switches the class to nginx for testing.
Nginx is proxying connections for our container registry and needs configuration to allow for a larger upload size.

* container-registry
* letsencrypt acme solver
* epinio server

TODO

- [x]  add option to choose class(es)

Refers to https://github.com/epinio/epinio/issues/1178



## Installing Nginx Ingress

### disable traefik

```
helm delete -n kube-system traefik
helm delete -n kube-system traefik-crd
```

### install&test nginx

From the upstream docs

```
helm upgrade --install ingress-nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx --namespace ingress-nginx --create-namespace

kubectl create deployment demo --image=httpd --port=80
kubectl expose deployment demo

kubectl create ingress demo-localhost --class=nginx --rule=demo.localdev.me/*=demo:80
# if port 80 is not how you reach the cluster
# kubectl port-forward --namespace=ingress-nginx service/ingress-nginx-controller 8080:80
```

# make nginx default

```
# won't affect existing ingresses, only newly created ones get the default class
kubectl patch ingressclass nginx --type=merge -p '{"metadata": { "annotations": {"ingressclass.kubernetes.io/is-default-class": "true"}}}'
```

> If you have lot of ingress objects without ingressClass configuration, you can run the ingress-controller with the flag --watch-ingress-without-class=true.

### Epinio

```
helm upgrade --install -n epinio --create-namespace --set domain=$EPINIO_SYSTEM_DOMAIN --set "skipLinkerd=true" --set "skipTraefik=true" epinio-installer ~/Downloads/epinio-installer-0.4.0.tgz
```

