### PR TITLE
fix: missing abort on error, and linkerd shutdown from init containers

### DIFF
--- a/chart/epinio/templates/stage-scripts.yaml
+++ b/chart/epinio/templates/stage-scripts.yaml
@@ -37,6 +37,10 @@ data:
     # the detected format more explicit in the output.
     #
     echo By _ _ __ ___ _____ $(whoami) $(pwd)
+    if test ! -f "/workspace/source/${BLOBID}" ; then
+      echo Nothing to unpack
+      exit
+    fi
     mkdir /workspace/source/app
     (  cd /workspace/source/app
        ( echo Tar? ; tar -xvf  "../${BLOBID}" 2>&1 | sed -e 's/^/Tar: /' ) || \
@@ -62,8 +66,14 @@ data:
     # container gracefully. We use `|| true` in case linkerd is not deployed.  Further, it
     # is placed into a trap to ensure that it will always run, even for a staging failure.
     #
+    set -e
     trap "curl -X POST http://localhost:4191/shutdown || true" EXIT
     echo By _ _ __ ___ _____ $(whoami) $(pwd)
+    if test ! -d "/workspace/source/app" ; then
+      echo Nothing to build
+      sleep 60 # linkerd is a pain - If we exit to quickly, with the sidecar not ready our curl to shut it down does nothing, and then the sidecar comes up and prevents the pod from ending
+      exit 1
+    fi
     find /workspace
     /cnb/lifecycle/creator \
       -app=/workspace/source/app \


### PR DESCRIPTION
Ref: https://github.com/epinio/epinio/issues/1209
See also https://github.com/epinio/epinio/pull/1210