### PR TITLE
feat: import of extended app CRD - field to store stage id

### DIFF
--- a/chart/epinio/templates/app-crd.yaml
+++ b/chart/epinio/templates/app-crd.yaml
@@ -72,6 +72,11 @@ spec:
                 items:
                   type: string
                 type: array
+              stageid:
+                description: StageID stores the id of the latest attempt to stage
+                  the application, regardless of outcome. This enables access to the
+                  staging logs of an application which never staged successfully.
+                type: string
             required:
             - origin
             type: object


### PR DESCRIPTION
Ref: https://github.com/epinio/epinio/issues/1162

For the underlying CRD change see https://github.com/epinio/application/pull/4

(Just copying the new yaml from the app CRD PR to its proper place in the chart)
