### PR TITLE
Epinio-ui helm chart

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -8,7 +8,7 @@ on:
     # Run every Monday at 9 AM
     - cron: '0 9 * * 1'
   repository_dispatch:
-    types: [epinio-release]
+    types: [epinio-release, epinio-ui-release]
 
 permissions:
   contents: write

--- a/chart/epinio-ui/.helmignore
+++ b/chart/epinio-ui/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/epinio-ui/Chart.yaml
+++ b/chart/epinio-ui/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: epinio-ui
+description: A Helm chart for the Epinio UI
+type: application
+version: 0.0.1
+maintainers:
+- name: SUSE
+  email: team@epinio.io

--- a/chart/epinio-ui/templates/_helpers.tpl
+++ b/chart/epinio-ui/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "epinio-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "epinio-ui.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "epinio-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "epinio-ui.labels" -}}
+helm.sh/chart: {{ include "epinio-ui.chart" . }}
+{{ include "epinio-ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "epinio-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "epinio-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "epinio-ui.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "epinio-ui.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/epinio-ui/templates/certificate.yaml
+++ b/chart/epinio-ui/templates/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: epinio-ui
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - {{ .Values.domain }}
+  issuerRef:
+    kind: ClusterIssuer
+    name: {{ .Values.tlsIssuer }}
+  secretName: epinio-ui-tls

--- a/chart/epinio-ui/templates/ingress.yaml
+++ b/chart/epinio-ui/templates/ingress.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+  labels:
+    {{- include "epinio-ui.labels" . | nindent 4 }}
+  name: epinio-ui
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: "{{ .Values.ingress.ingressClassName }}"
+  {{- end }}
+  rules:
+  - host: {{ .Values.domain }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: epinio-ui
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - {{ .Values.domain }}
+    secretName: epinio-ui-tls

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -1,0 +1,91 @@
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "epinio-ui").data -}}
+{{- $encryptionKey := empty $secret | ternary (printf "%x" (randAscii 32)) (b64dec (default "" $secret.encryptionKey)) -}}
+{{- $sessionSecret := empty $secret | ternary (randAlphaNum 16) (b64dec (default "" $secret.sessionSecret)) -}}
+
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: epinio-ui
+  namespace: {{ .Release.Namespace }}
+stringData:
+  encryptionKey: {{ $encryptionKey }}
+  sessionSecret: {{ $sessionSecret }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: epinio-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "epinio-ui.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "epinio-ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "epinio-ui.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: epinio-ui
+        image: {{ .Values.epinioUI.image }}
+        imagePullPolicy: {{ .Values.epinioUI.imagePullPolicy }}
+        workingDir: /db
+
+        env:
+        - name: EPINIO_API_URL
+          value: {{ .Values.epinioApiUrl | quote }}
+        - name: EPINIO_API_SKIP_SSL
+          value: {{ .Values.epinioApiSkipSSL | quote }}
+        - name: SESSION_STORE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: epinio-ui
+              key: sessionSecret
+        - name: UI_PATH
+          value: "/ui"
+        - name: AUTH_ENDPOINT_TYPE
+          value: epinio
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: epinio-ui
+              key: encryptionKey
+
+        - name: DATABASE_PROVIDER
+          value: sqlite
+        - name: HTTPS
+          value: "false"
+        - name: CONSOLE_PROXY_TLS_ADDRESS
+          value: 0.0.0.0:8000
+        - name: LOG_LEVEL
+          value: {{ .Values.logLevel | quote }}
+
+        {{- with .Values.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/chart/epinio-ui/templates/service.yaml
+++ b/chart/epinio-ui/templates/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: epinio-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "epinio-ui.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "epinio-ui.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: ui
+    port: 80
+    targetPort: 8000

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -1,5 +1,5 @@
 epinioUI:
-  image: ghcr.io/epinio/epinio-ui:v0.0.1-2
+  image: ghcr.io/epinio/epinio-ui:v0.0.1-3
   imagePullPolicy: IfNotPresent
 
 ingress:

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -1,0 +1,40 @@
+epinioUI:
+  image: ghcr.io/epinio/epinio-ui:v0.0.1-2
+  imagePullPolicy: IfNotPresent
+
+ingress:
+  # The ingressClassName is used to select the ingress controller. If empty no class will be added to the ingresses.
+  ingressClassName: ""
+
+tlsIssuer: selfsigned-issuer
+
+logLevel: info
+
+domain: ui.epinio.dev
+
+# API URL of epinio instance, for proxied connections
+epinioApiUrl: http://epinio-server.epinio.svc.cluster.local
+
+# Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`
+epinioApiSkipSSL: "true"
+
+volumeMounts:
+- name: tmp
+  mountPath: /tmp
+  readOnly: false
+- name: db
+  mountPath: /db
+  readOnly: false
+# - name: ui
+#   mountPath: /ui
+#   subPath: dist
+#   readOnly: true
+
+volumes:
+- name: tmp
+  emptyDir: {}
+- name: db
+  emptyDir: {}
+# - name: ui
+#   persistentVolumeClaim:
+#     claimName: ui

--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -1,0 +1,49 @@
+---
+title: "Bump epinio ui version"
+# Define git repository configuration to know where to push changes
+scms:
+  helm-charts:
+    kind: "github"
+    spec:
+      user: "{{ .github.epinio.user }}"
+      email: "{{ .github.epinio.email }}"
+      owner: "{{ .github.epinio.owner }}"
+      repository: "{{ .github.epinio.repository }}"
+      token: '{{ requiredEnv .github.epinio.token }}'
+      username: "{{ .github.epinio.username }}"
+      branch: "{{ .github.epinio.branch }}"
+
+# Defines where we get source values
+sources:
+  ui-backend-tag:
+    kind: gitTag
+    scm:
+      git:
+        url: https://epinio.github.io/ui-backend
+
+# Defines what needs to be udpated if needed
+targets:
+  epinio-ui-chart:
+    name: "Update ui-backend image in chart epinio-ui"
+    kind: "helmChart"
+    scmID: "helm-charts"
+    sourceID: "ui-backend-tag"
+    spec:
+      name: "chart/epinio-ui"
+      file: "values.yaml"
+      key: "epinioUI.image"
+      value: 'ghcr.io/epinio/epinio-ui:{{ source "ui-backend-tag" }}'
+      versionIncrement: minor
+
+# Define pullrequest configuration if one needs to be created
+pullrequests:
+  helm-charts:
+    kind: "github"
+    scmID: "helm-charts"
+    targets:
+      - "helm-charts"
+    spec:
+      labels:
+        - "dependencies"
+        - "epinio-ui"
+


### PR DESCRIPTION
This is the helm chart for the standalone UI (https://github.com/epinio/ui/issues/68)

Usage:

```
helm upgrade --install --namespace epinio \
  --set domain=ui.<IP>.omg.howdoi.website \
  epinio-ui chart/epinio-ui
```

TODO:

- [x] working ui bundle in docker image
- [x] repository dispatch/updatecli from ui-backend repo to bump chart
- [x] use current bundle

# Notes

## Optional: Re-using the epinio ingress

Install with `--set domain=epinio.<IP>.omg.howdoi.website`

Modify the existing epinio ingress:
```
# add to epinio ingress
http:
  paths:
  - backend:
      service:
        name: epinio-ui
        port:
          number: 80
    path: /
    pathType: ImplementationSpecific
  - backend:
      service:
        name: epinio-server
        port:
          number: 80
    path: /api
    pathType: ImplementationSpecific
  - backend:
      service:
        name: epinio-server
        port:
          number: 80
    path: /wapi
    pathType: ImplementationSpecific
  - backend:
      service:
        name: epinio-server
        port:
          number: 80
    path: /ready
    pathType: ImplementationSpecific
```

## Optional: replace UI bundle locally

We can copy the UI bundle to a volume, then mount that volume to the ui pod's '/ui' folder


```
#  kubectl apply -n epinio -f- <<EOF
---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: ui
spec:
  storageClassName: local-path
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
---
kind: Pod
apiVersion: v1
metadata:
  name: copy
spec:
  containers:
  - image: busybox
    name: busybox
    command:
    - sleep
    - "1000"
    volumeMounts:
    - name: vol
      mountPath: /mnt
      readOnly: false
  volumes:
    - name: vol
      persistentVolumeClaim:
        claimName: ui
# EOF

# zcat dist.tar.gz | kubectl exec -i -n epinio copy -- tar xf - -C /mnt/
# kubectl delete pod -n epinio copy
```

Then, uncomment volumes in values.yaml.