### PR TITLE
Add tmp volume to epinio server

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -237,6 +237,9 @@ spec:
       name: epinio-server
     spec:
       serviceAccountName: epinio-server
+      volumes:
+      - name: tmp-volume
+        emptyDir: {}
       containers:
         - command: ["/epinio", "server"]
           args: ["--port", "80"]
@@ -267,6 +270,9 @@ spec:
           name: epinio-server
           ports:
             - containerPort: 80
+          volumeMounts:
+          - name: tmp-volume
+            mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
to allow the usage of a scratch based container and separate the tmp
data from the node.