### PR TITLE
Fix CI to work with latest epinio's changes

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -48,6 +48,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Prepare CI env before installing epinio
+        run: make prepare-ci-env
+        if: steps.list-changed.outputs.changed == 'true'
+
       - name: Run chart-testing
-        run: ct install --config ct/ct.yaml
+        run: ct install --debug --config ct/ct.yaml --namespace epinio
         if: steps.list-changed.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build-charts-ci: ## Build and push Helm charts to a local repo (chartmuseum)
-	@./scripts/build-charts-ci.sh
+prepare-ci-env: ## Prepare the CI env before installing Epinio
+	@./scripts/prepare-ci-env.sh
 help: ## Show this Makefile's help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/scripts/prepare-ci-env.sh
+++ b/scripts/prepare-ci-env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Install cert-manager
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm upgrade --install cert-manager jetstack/cert-manager -n cert-manager --create-namespace --set installCRDs=true --set extraArgs[0]=--enable-certificate-owner-ref=true
+
+# Set localhost to domain
+sed -i 's/domain: ""/domain: "localhost"/g' chart/epinio/values.yaml 
+
+# Create namespace epinio (hardcoded)
+kubectl create ns epinio


### PR DESCRIPTION
A lot of changes has been pushed to epinio (epinio-server and epinio chart) and the CI is not adapted anymore.
This PR fixes the CI.

Screenshot of a successful installation with `ct install`:

<img width="1063" alt="Screenshot 2022-02-24 at 16 59 07" src="https://user-images.githubusercontent.com/6025636/155560881-1bcf4b44-bb86-482a-b20f-a74039784a7d.png">
