### PR TITLE
Remove "without dependencies" message

### DIFF
--- a/chart/epinio/Chart.yaml
+++ b/chart/epinio/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   tags:
   - kubed
   version: 0.13.1
-description: The Epinio component (without dependencies)
+description: The official way to install Epinio
 home: https://github.com/epinio/epinio
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 keywords:


### PR DESCRIPTION
Remove "without dependencies" message out of the Epinio helm chart description