### PR TITLE
Add questions.yml to epinio single chart

### DIFF
--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -1,0 +1,154 @@
+questions:
+- variable: email
+  label: Email
+  description: "Email to use for getting notifications about your certificates"
+  type: strings
+  required: false
+  group: "General settings"
+- variable: certManagerNamespace
+  label: Cert-manager namespace
+  description: "Namespace where cert-manager is installed in"
+  type: strings
+  required: false
+  group: "Advanced settings"
+- variable: ingress.ingressClassName
+  label: Ingress class name for the server
+  description: "Set a class name to select the ingress controller you want to use for the server"
+  type: strings
+  group: "Advanced settings"
+- variable: server.ingressClassName
+  label: Ingress class name for apps
+  description: "Set a class name to select the ingress controller you want to use for your apps"
+  type: strings
+  group: "Advanced settings"
+- variable: useCustomTlsIssuer
+  label: Use your own TLS issuer
+  default: "false"
+  description: "Use your own TLS issuer"
+  type: boolean
+  group: "General settings"
+  show_subquestion_if: true
+  subquestions:
+  - variable: customTlsIssuer
+    label: TLS issuer
+    description: "Name of the cluster issuer to use"
+    type: strings
+    required: false
+- variable: global.tlsIssuer
+  show_if: "useCustomTlsIssuer=false"
+  label: TLS issuer
+  description: "Name of the predefined cluster issuer to use"
+  type: enum
+  required: false
+  group: "General settings"
+  options:
+    - "epinio-ca"
+    - "selfsigned-issuer"
+    - "letsencrypt-production"
+- variable: api.username
+  label: API username
+  description: "The user name for authenticating all API requests"
+  type: strings
+  required: false
+  group: "General settings"
+- variable: api.password
+  label: API password
+  description: "The password for authenticating all API requests"
+  type: password
+  required: false
+  group: "General settings"
+- variable: global.domain
+  label: Domain
+  description: "Domain for the application"
+  type: strings
+  required: true
+  group: "General settings"
+- variable: server.accessControlAllowOrigin
+  label: Access control allow origin
+  description: "Domain which serves the Rancher UI (to access the API)"
+  type: strings
+  required: false
+  group: "General settings"
+- variable: kubed.enabled
+  label: Install kubed
+  description: "Deploy kubed or skip it if you get it installed already"
+  type: boolean
+  group: "Advanced settings"
+- variable: containerregistry.enabled
+  description: "Disable local container registry to configure an external registry."
+  label: Install local container registry
+  type: boolean
+  show_subquestion_if: false
+  group: "External registry"
+  subquestions:
+  - variable: global.registryURL
+    label: External registry url
+    description: "URL of your external registry"
+    type: strings
+    required: false
+  - variable: global.registryUsername
+    label: External registry username
+    description: "Username to authenticate to the external registry"
+    type: strings
+    required: false
+  - variable: global.registryPassword
+    label: External registry password
+    description: "Password to authenticate to the external registry"
+    type: password
+    required: false
+  - variable: global.registryNamespace
+    label: External registry namespace
+    description: "Namespace of the external registry where you have push access"
+    type: strings
+    required: false
+- variable: minio.enabled
+  label: Install Minio
+  description: "Disable Minio to configure an external s3 storage."
+  type: boolean
+  show_subquestion_if: false
+  group: "External S3 storage"
+  subquestions:
+  - variable: s3.endpoint
+    label: S3 endpoint
+    description: "Endpoint of your S3 storage"
+    type: strings
+    required: false
+  - variable: s3.accessKeyID
+    label: S3 access key id
+    description: "Access key id to authenticate to your S3 storage"
+    type: strings
+    required: false
+  - variable: s3.secretAccessKey
+    label: S3 access key secret
+    description: "Secret access key to authenticate to your S3 storage"
+    type: password
+    required: false
+  - variable: s3.bucket
+    label: S3 bucket
+    description: "Bucket of your S3 storage"
+    type: strings
+    required: false
+  - variable: s3.region
+    label: S3 region
+    description: "Region of your S3 storage"
+    type: strings
+    required: false
+  - variable: s3.useSSL
+    label: S3 use SSL
+    type: boolean
+    required: false
+  - variable: s3.certificateSecret
+    label: Self signed certificate for S3
+    description: Set it to an existing secret if s3 is using a self signed certificate
+    type: strings
+    required: false
+- variable: server.traceLevel
+  label: Epinio API Log Level
+  required: false
+  type: strings
+  group: "Debugging"
+- variable: server.timeoutMultiplier
+  label: Timeout Multiplier
+  required: false
+  type: strings
+  group: "Debugging"


### PR DESCRIPTION
Fix https://github.com/epinio/epinio/issues/1247

This is a first glance, it could be improved.
When I was doing my tests, I've found an issue with external registry. I will track it in another issue.

It's not possible to add more conditional logic in the file, it's very limited (https://www.rancher.co.jp/docs/rancher/v2.x/en/catalog/custom/creating/#question-variable-reference)
So I tried to do it as clear as possible but we will likely adapt it after getting feedback.

**Note:** Cypress tests have to be updated

Installation only works in epinio namespace with epinio as deployment name (likely due to some hard-coded things):
![image](https://user-images.githubusercontent.com/6025636/156458332-84b7fd91-f745-456c-b200-a024195b6f5c.png)


## These are all the screens the user will see:

### General settings screen:
<img width="1644" alt="image" src="https://user-images.githubusercontent.com/6025636/156456020-39a92be3-ccd2-4911-9574-ca45bb648a5e.png">

### Advanced settings screen:
<img width="1747" alt="image" src="https://user-images.githubusercontent.com/6025636/156456167-678d8774-e9e7-4cc1-a431-ef42c32a43a2.png">

### External registry screen 1:
<img width="1683" alt="image" src="https://user-images.githubusercontent.com/6025636/156456505-38dac0a2-f446-44f0-884f-02bdf0cfed4a.png">
`Install local container registry` has to be unchecked to make external registry options appear (check next screen below)

### External registry screen 2:
<img width="1683" alt="image" src="https://user-images.githubusercontent.com/6025636/156456363-8306ff02-207b-49a4-8ada-253450cc942e.png">

### External S3 storage screen 1:
<img width="1587" alt="image" src="https://user-images.githubusercontent.com/6025636/156456855-1b6ed842-8285-4a0d-b69f-c40eff2ccf35.png">
`Install minio` has to be unchecked to make external s3 storage options appear (check next screen below)

### External S3 storage screen 2:
<img width="1656" alt="image" src="https://user-images.githubusercontent.com/6025636/156457086-96e834a4-2e1a-4b56-bc56-09a257a6769f.png">

### Debugging screen:
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/6025636/156457167-b2168ce6-2f67-469a-b501-f60f77c4931e.png">

