### PR TITLE
Update epinio ui chart with latest build and env vars

### DIFF
--- a/chart/epinio-ui/Chart.yaml
+++ b/chart/epinio-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: epinio-ui
 description: A Helm chart for the Epinio UI
 type: application
-version: 0.0.1
+version: 0.0.2
 maintainers:
 - name: SUSE
   email: team@epinio.io

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -41,11 +41,15 @@ spec:
           value: {{ .Values.epinioApiUrl | quote }}
         - name: EPINIO_API_SKIP_SSL
           value: {{ .Values.epinioApiSkipSSL | quote }}
+        - name: EPINIO_VERSION
+          value: {{ .Values.epinioVersion | quote }}
         - name: SESSION_STORE_SECRET
           valueFrom:
             secretKeyRef:
               name: epinio-ui
               key: sessionSecret
+        - name: SESSION_STORE_EXPIRY
+          value: 1440
         - name: UI_PATH
           value: "/ui"
         - name: AUTH_ENDPOINT_TYPE

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -49,7 +49,7 @@ spec:
               name: epinio-ui
               key: sessionSecret
         - name: SESSION_STORE_EXPIRY
-          value: 1440
+          value: "1440"
         - name: UI_PATH
           value: "/ui"
         - name: AUTH_ENDPOINT_TYPE

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -1,5 +1,5 @@
 epinioUI:
-  image: ghcr.io/epinio/epinio-ui:v0.0.1-4
+  image: ghcr.io/epinio/epinio-ui:v0.0.1-5
   imagePullPolicy: IfNotPresent
 
 ingress:

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -1,5 +1,5 @@
 epinioUI:
-  image: ghcr.io/epinio/epinio-ui:v0.0.1-3
+  image: ghcr.io/epinio/epinio-ui:v0.0.1-4
   imagePullPolicy: IfNotPresent
 
 ingress:
@@ -17,6 +17,9 @@ epinioApiUrl: http://epinio-server.epinio.svc.cluster.local
 
 # Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`
 epinioApiSkipSSL: "true"
+
+# This is the version that is displayed in the ui and should match that of the epinio it's targetting
+epinioVersion: "0.5.0"
 
 volumeMounts:
 - name: tmp


### PR DESCRIPTION
- Bump the image to 0.0.4
- Add an expiry time for the session (though until polling is replaced this probably won't be hit)
- Add an Epinio Version (which will be shown in the ui and should match the targetted epinio instance)