### PR TITLE
Update updatecli pipeline for ui-backend

### DIFF
--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -13,21 +13,35 @@ scms:
       username: "{{ .github.epinio.username }}"
       branch: "{{ .github.epinio.branch }}"
 
+  ui-backend:
+    kind: "git"
+    spec:
+      url: "https://github.com/epinio/ui-backend.git"
+      branch: "main"
+
 # Defines where we get source values
 sources:
   ui-backend-tag:
-    kind: gitTag
-    scm:
-      git:
-        url: https://epinio.github.io/ui-backend
+    name: "Get latest Epinio UI backend git tag"
+    kind: "gittag"
+    scmID: ui-backend
 
-# Defines what needs to be udpated if needed
+conditions:
+  dockerImage:
+    name: 'Check that ghcr.io/epinio/epinio-ui:{{ source "ui-backend-tag" }} exists'
+    kind: "dockerImage"
+    sourceID: "ui-backend-tag"
+    spec:
+      image: "ghcr.io/epinio/epinio-ui"
+
 targets:
   epinio-ui-chart:
-    name: "Update ui-backend image in chart epinio-ui"
+    name: "Update Epinio UI backend image for Helm Chart chart/epinio-ui"
     kind: "helmChart"
     scmID: "helm-charts"
     sourceID: "ui-backend-tag"
+    transformers:
+      - addPrefix: "ghcr.io/epinio/epinio-ui:"
     spec:
       name: "chart/epinio-ui"
       file: "values.yaml"
@@ -41,8 +55,9 @@ pullrequests:
     kind: "github"
     scmID: "helm-charts"
     targets:
-      - "helm-charts"
+      - "epinio-ui-chart"
     spec:
+      automerge: true
       labels:
         - "dependencies"
         - "epinio-ui"


### PR DESCRIPTION
Fix updatecli pipeline for the Epinio UI helm chart

Tested locally 
```
 updatecli diff --config updatecli/updatecli.d/epinio-ui.yaml --values updatecli/values.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/epinio-ui.yaml"
Repository retrieved: 2


++++++++++++
+ PIPELINE +
++++++++++++



##########################
# BUMP EPINIO UI VERSION #
##########################


SOURCES
=======

ui-backend-tag
--------------
Searching for version matching pattern "latest"
✔ Git tag "v0.0.1-4" found matching pattern "latest"


CONDITIONS:
===========

dockerImage
-----------
WARNING: No architecture specified for the image "ghcr.io/epinio/epinio-ui:". Using the default "amd64".
✔ The Docker image ghcr.io/epinio/epinio-ui:v0.0.1-4 exists and is available.


TARGETS
========

epinio-ui-chart
---------------

**Dry Run enabled**

INFO: Using spec.Value instead of source input value.
⚠ Key 'epinioUI.image', from file '/tmp/updatecli/epinio/helm-charts/chart/epinio-ui/values.yaml', was updated from 'ghcr.io/epinio/epinio-ui:v0.0.1-3' to 'ghcr.io/epinio/epinio-ui:v0.0.1-4'


PULL REQUESTS
=============

[Dry Run] A pull request with kind "github" and title "[updatecli] Bump epinio ui version" is expected.

=============================

REPORTS:


⚠ EPINIO-UI.YAML:
	Sources:
		✔ [ui-backend-tag] Get latest ui-backend git tag (kind: gittag)
	Condition:
		✔ [dockerImage] Check that ghcr.io/epinio/epinio-ui:v0.0.1-4 is published (kind: dockerImage)
	Target:
		⚠ [epinio-ui-chart] Update ui-backend image in chart epinio-ui (kind: helmChart)



Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

```

Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>
