### PR TITLE
Remove registry ingress

### DIFF
--- a/chart/epinio/templates/_helpers.tpl
+++ b/chart/epinio/templates/_helpers.tpl
@@ -1,5 +1,19 @@
+{{/*
+URL prefix for container images to be compatible with Rancher
+*/}}
 {{- define "registry-url" -}}
 {{- if .Values.registryURL -}}
 {{ trimSuffix "/" .Values.registryURL }}/
+{{- end -}}
+{{- end -}}
+
+{{/*
+URL of the registry epinio uses to store workload images
+*/}}
+{{- define "epinio.registry-url" -}}
+{{- if .Values.containerregistry.enabled -}}
+{{-   print "registry.epinio-staging.svc.cluster.local:5000" }}
+{{- else -}}
+{{-   print .Values.global.registryURL }}
 {{- end -}}
 {{- end -}}

--- a/chart/epinio/templates/certificate.yaml
+++ b/chart/epinio/templates/certificate.yaml
@@ -8,7 +8,7 @@ spec:
   - epinio.{{ .Values.global.domain }}
   issuerRef:
     kind: ClusterIssuer
-    name: {{ .Values.global.tlsIssuer }}
+    name: {{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer | quote }}
   secretName: epinio-tls
 
 {{- if .Values.minio.enabled }}

--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -60,48 +60,27 @@ spec:
     app.kubernetes.io/name: "epinio-registry"
     app.kubernetes.io/instance: "epinio-registry"
   ports:
-  - name: registry
-    port: 5000
-    targetPort: 5000
+  - name: registry-sidecar
+    port: 30500
+    targetPort: 30500
     nodePort: 30500
-{{- end }}
-
 ---
-apiVersion: apps/v1
-kind: DaemonSet
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: registry-ds
+  name: nginx-conf
   namespace: epinio-staging
-  labels:
-    app.kubernetes.io/name: "registry-ds"
-    app.kubernetes.io/instance: "registry-ds"
-spec:
-  selector:
-    matchLabels:
-      name: registry-ds
-  template:
-    metadata:
-      labels:
-        name: registry-ds
-    spec:
-      containers:
-      - name: registry-ds
-        image: busybox
-        command: [ 'sh' ]
-        args: [ '-c', 'mkdir -p /etc/docker/certs.d/127.0.0.1:30500 && cp -f /mnt/certs/ca.crt /etc/docker/certs.d/127.0.0.1:30500/ca.crt && exec tail -f /dev/null' ]
-        volumeMounts:
-        - name: etc-docker
-          mountPath: /etc/docker/certs.d
-        - name: ca-cert
-          mountPath: /mnt/certs
-      terminationGracePeriodSeconds: 30
-      volumes:
-      - name: etc-docker
-        hostPath:
-          path: /etc/docker/certs.d
-      - name: ca-cert
-        secret:
-          secretName: epinio-registry-tls
+data:
+  nginx.conf: |
+    server {
+      listen 30500 default_server;
+      server_name 127.0.0.1;
+
+      location / {
+        proxy_pass https://localhost:5000/;
+      }
+    }
+{{- end }}
 
 ---
 apiVersion: apps/v1
@@ -125,6 +104,31 @@ spec:
         app.kubernetes.io/instance: "epinio-registry"
     spec:
       containers:
+{{ if .Values.containerregistry.createNodePort }}
+      - name: nginx
+        image: nginx:1.21
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          tcpSocket:
+            port: 5000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          tcpSocket:
+            port: 5000
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d
+          name: nginx-conf
+        - mountPath: /var/cache/nginx/
+          name: nginx-run
+        - mountPath: /var/run/
+          name: nginx-run
+{{- end }}
       - name: registry
         image: {{ .Values.containerregistry.image }}
         imagePullPolicy: {{ .Values.containerregistry.imagePullPolicy }}
@@ -175,4 +179,13 @@ spec:
       - name: certs
         secret:
           secretName: epinio-registry-tls
+{{ if .Values.containerregistry.createNodePort }}
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+{{- end }}
 {{- end }}

--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -4,17 +4,33 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: auth
-  namespace: {{ .Release.Namespace }}
+  namespace: epinio-staging
 stringData:
   # The only supported password format is bcrypt
   htpasswd:  {{ htpasswd .Values.global.registryUsername .Values.global.registryPassword | quote }}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: epinio-registry
+  namespace: epinio-staging
+spec:
+  dnsNames:
+  - registry.epinio-staging.svc.cluster.local
+  ipAddresses:
+  - 127.0.0.1
+  issuerRef:
+    kind: ClusterIssuer
+    name: epinio-ca
+  secretName: epinio-registry-tls
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: registry
-  namespace: {{ .Release.Namespace }}
+  namespace: epinio-staging
   labels:
     app.kubernetes.io/name: "epinio-registry"
     app.kubernetes.io/instance: "epinio-registry"
@@ -28,62 +44,13 @@ spec:
     port: 5000
     targetPort: 5000
 
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: epinio-registry
-  namespace: {{ .Release.Namespace }}
-spec:
-  dnsNames:
-  - "epinio-registry.{{ .Values.global.domain }}"
-  issuerRef:
-    kind: ClusterIssuer
-    name: {{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer | quote }}
-  secretName: epinio-registry-tls
-  secretTemplate:
-    annotations:
-      kubed.appscode.com/sync: "kubed-registry-tls-from={{ .Release.Namespace }}" # Sync certificate to matching namespaces
-
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
-  labels:
-    app.kubernetes.io/name: "epinio-registry"
-    app.kubernetes.io/instance: "epinio-registry"
-  name: registry
-  namespace: {{ .Release.Namespace }}
-spec:
-  {{- if .Values.containerregistry.ingressClassName }}
-  ingressClassName: "{{ .Values.containerregistry.ingressClassName }}"
-  {{- end }}
-  rules:
-  - host: "epinio-registry.{{ .Values.global.domain }}"
-    http:
-      paths:
-      - backend:
-          service:
-            name: registry
-            port:
-              number: 5000
-        path: /
-        pathType: ImplementationSpecific
-  tls:
-  - hosts:
-    - "epinio-registry.{{ .Values.global.domain }}"
-    secretName: epinio-registry-tls
-
 {{ if .Values.containerregistry.createNodePort }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: registry-node
-  namespace: {{ .Release.Namespace }}
+  namespace: epinio-staging
   labels:
     app.kubernetes.io/name: "epinio-registry"
     app.kubernetes.io/instance: "epinio-registry"
@@ -101,10 +68,47 @@ spec:
 
 ---
 apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: registry-ds
+  namespace: epinio-staging
+  labels:
+    app.kubernetes.io/name: "registry-ds"
+    app.kubernetes.io/instance: "registry-ds"
+spec:
+  selector:
+    matchLabels:
+      name: registry-ds
+  template:
+    metadata:
+      labels:
+        name: registry-ds
+    spec:
+      containers:
+      - name: registry-ds
+        image: busybox
+        command: [ 'sh' ]
+        args: [ '-c', 'mkdir -p /etc/docker/certs.d/127.0.0.1:30500 && cp -f /mnt/certs/ca.crt /etc/docker/certs.d/127.0.0.1:30500/ca.crt && exec tail -f /dev/null' ]
+        volumeMounts:
+        - name: etc-docker
+          mountPath: /etc/docker/certs.d
+        - name: ca-cert
+          mountPath: /mnt/certs
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: etc-docker
+        hostPath:
+          path: /etc/docker/certs.d
+      - name: ca-cert
+        secret:
+          secretName: epinio-registry-tls
+
+---
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: registry
-  namespace: {{ .Release.Namespace }}
+  namespace: epinio-staging
   labels:
     app.kubernetes.io/name: "epinio-registry"
     app.kubernetes.io/instance: "epinio-registry"
@@ -131,6 +135,10 @@ spec:
           value: Registry Realm
         - name: REGISTRY_AUTH_HTPASSWD_PATH
           value: /etc/registry/auth/htpasswd
+        - name: REGISTRY_HTTP_TLS_CERTIFICATE
+          value: "/certs/tls.crt"
+        - name: REGISTRY_HTTP_TLS_KEY
+          value: "/certs/tls.key"
         volumeMounts:
         - name: registry
           mountPath: /var/lib/registry
@@ -138,19 +146,24 @@ spec:
         - name: auth
           mountPath: /etc/registry/auth
           readOnly: true
+        - name: certs
+          mountPath: /certs
+          readOnly: true
         securityContext:
           runAsUser: 1000
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
         livenessProbe:
-          tcpSocket:
+          httpGet:
             port: 5000
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
-          tcpSocket:
+          httpGet:
             port: 5000
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 5
       volumes:
@@ -159,4 +172,7 @@ spec:
       - name: auth
         secret:
           secretName: auth
+      - name: certs
+        secret:
+          secretName: epinio-registry-tls
 {{- end }}

--- a/chart/epinio/templates/registry-secret.yaml
+++ b/chart/epinio/templates/registry-secret.yaml
@@ -1,7 +1,3 @@
-{{- $registryURL := .Values.global.registryURL }}
-{{- if .Values.containerregistry.enabled -}}
-{{- $registryURL = (print "epinio-registry." .Values.global.domain) -}}
-{{- end -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,7 +12,7 @@ stringData:
   .dockerconfigjson: |-
     {
       "auths": {
-        "{{ $registryURL }}": {
+        "{{ template "epinio.registry-url" . }}": {
           "auth":"{{ printf "%s:%s" .Values.global.registryUsername .Values.global.registryPassword | b64enc }}",
           "username":"{{ .Values.global.registryUsername }}",
           "password":"{{ .Values.global.registryPassword }}"

--- a/chart/epinio/templates/staging-namespace.yaml
+++ b/chart/epinio/templates/staging-namespace.yaml
@@ -6,10 +6,7 @@ metadata:
   annotations:
     linkerd.io/inject: enabled
   labels:
-  # label so that kubed copies epinio-registry and s3 secret to this namespace
-  {{- if .Values.containerregistry.enabled }}
-    kubed-registry-tls-from: {{ .Release.Namespace }}
-  {{- end }}
+  # label so that kubed copies s3 secret to this namespace
   {{- if .Values.minio.enabled }}
     kubed-s3-tls-from: {{ .Release.Namespace }}
   {{- end }}


### PR DESCRIPTION
* removes registry ingress (`epinio-registry.$domain`)
* uses cluster DNS `registry.epinio-staging.svc.cluster.local` for internal registry
* enables TLS for internal registry
* adds sidecar for NodePort `127.0.0.1:30500`, so container runtime can access the registry via http (no need to trust our private CA)

fixes [#1276](https://github.com/epinio/epinio/issues/1276)
fixes https://github.com/epinio/helm-charts/issues/133