### PR TITLE
Chart testing install test only test epinio

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -53,5 +53,5 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing
-        run: ct install --debug --config ct/ct.yaml --namespace epinio
+        run: ct install --debug --config ct/ct-install.yaml --namespace epinio
         if: steps.list-changed.outputs.changed == 'true'

--- a/ct/ct-install.yaml
+++ b/ct/ct-install.yaml
@@ -1,0 +1,11 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+check-version-increment: false
+chart-dirs:
+  - chart
+chart-repos:
+  - minio=https://charts.min.io
+  - appscode=https://charts.appscode.com/stable/
+charts: chart/epinio
+helm-extra-args: --timeout 600s


### PR DESCRIPTION
We only want to test epinio helm chart installation. Chart testing will skip the other charts which are in the chart directory.

Tested successfully here: https://github.com/epinio/helm-charts/runs/5477352545?check_suite_focus=true
I had to change something in the epinio chart to trigger the installation test 😃 