### PR TITLE
Update NOTES.txt with epinio settings command

### DIFF
--- a/chart/epinio/templates/NOTES.txt
+++ b/chart/epinio/templates/NOTES.txt
@@ -8,7 +8,7 @@ Make sure your domain points to the IP address of your Ingress controller (1.2.3
 To interract with your Epinio installation, you have to download the latest epinio binary https://github.com/epinio/epinio/releases.
 
 Update the api location and credentials with:
-`epinio config update`
+`epinio settings update`
 
 Then, you have to run `epinio namespace create workspace`
 


### PR DESCRIPTION
The `epinio config` command has been replaced by `epinio settings`. 
We need to update NOTES.txt with the new command.