### PR TITLE
Fix some missing chart annotations (keywords, logo, sources, home)

### DIFF
--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -13,3 +13,5 @@ maintainers:
   name: SUSE
 sources:
 - https://github.com/epinio/helm-charts
+annotations:
+  artifacthub.io/license: Apache-2.0

--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -5,6 +5,11 @@ icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.pn
 home: https://github.com/epinio/epinio
 type: application
 version: 0.1.13
+keywords:
+- epinio
+- paas
 maintainers:
 - email: team@epinio.io
   name: SUSE
+sources:
+- https://github.com/epinio/helm-charts

--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.13
+version: 0.1.14
 keywords:
 - epinio
 - paas

--- a/chart/application/values.yaml
+++ b/chart/application/values.yaml
@@ -38,7 +38,7 @@ epinio:
   # namespace: .Release.Namespace
   replicaCount: 1
   stageID: 999
-  imageURL: curl
+  imageURL: ~
   username: user
   routes: ~
   env: ~

--- a/chart/epinio-ui/Chart.yaml
+++ b/chart/epinio-ui/Chart.yaml
@@ -6,3 +6,10 @@ maintainers:
 name: epinio-ui
 type: application
 version: 0.1.0
+keywords:
+- epinio
+- paas
+sources:
+- https://github.com/epinio/ui
+icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
+home: https://github.com/epinio/epinio

--- a/chart/epinio-ui/Chart.yaml
+++ b/chart/epinio-ui/Chart.yaml
@@ -13,3 +13,5 @@ sources:
 - https://github.com/epinio/ui
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
+annotations:
+  artifacthub.io/license: Apache-2.0

--- a/chart/epinio/Chart.yaml
+++ b/chart/epinio/Chart.yaml
@@ -26,3 +26,5 @@ name: epinio
 sources:
 - https://github.com/epinio/epinio
 version: 0.7.1
+annotations:
+  artifacthub.io/license: Apache-2.0


### PR DESCRIPTION
Fix https://github.com/epinio/epinio/issues/1300

Fixed:
  - missing license information (all)
  - missing keywords, source ref (ui, application)
  - missing logo, home (ui)
  - bogus image reference `curl` in the app chart's default `values.yaml`.

The last one should fix artifact hub notification noise for the application chart.
The message in the mails is
> error scanning image curl: image not found (package epinio-application:0.1.3)


