### PR TITLE
Add option to pass map of annotations to API ingress

### DIFF
--- a/chart/epinio/templates/ingress.yaml
+++ b/chart/epinio/templates/ingress.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: epinio
   name: epinio

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -36,6 +36,9 @@ server:
 ingress:
   # The ingressClassName is used to select the ingress controller for the server. If empty no class will be added to the ingresses.
   ingressClassName: ""
+  # Annotations to add to the API ingress
+  # e.g.: --set 'ingress.annotations.nginx\.ingress\.kubernetes\.io/ssl-redirect=false'
+  annotations: {}
 
 certManagerNamespace: cert-manager
 


### PR DESCRIPTION
With this option one can pass annotations to the API server's ingress.

For example to enable http with nginx ingress:

`--set 'ingress.annotations.nginx\.ingress\.kubernetes\.io/ssl-redirect=false'`