### PR TITLE
Provide Image References for Staging Support To Kube Resources

### DIFF
--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -106,7 +106,7 @@ spec:
       containers:
 {{ if .Values.containerregistry.createNodePort }}
       - name: nginx
-        image: nginx:1.21
+        image: "{{ template "registry-url" . }}{{ .Values.containerregistry.image.nginx.repository}}:{{ .Values.containerregistry.image.nginx.tag }}"
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000
@@ -130,7 +130,7 @@ spec:
           name: nginx-run
 {{- end }}
       - name: registry
-        image: {{ .Values.containerregistry.image }}
+        image: "{{ template "registry-url" . }}{{ .Values.containerregistry.image.registry.repository}}:{{ .Values.containerregistry.image.registry.tag }}"
         imagePullPolicy: {{ .Values.containerregistry.imagePullPolicy }}
         env:
         - name: REGISTRY_AUTH

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -288,7 +288,7 @@ spec:
             - name: INGRESS_CLASS_NAME
               value: "{{ .Values.ingress.ingressClassName }}"
             {{- end }}
-          image: "{{ template "registry-url" . }}{{ .Values.image.epinio.repository}}:{{ or .Values.image.epinio.tag .Chart.AppVersion }}"
+          image: "{{ default .Values.image.epinio.registry (include "registry-url" .) }}{{ .Values.image.epinio.repository }}:{{ default .Chart.AppVersion .Values.image.epinio.tag }}"
           livenessProbe:
             httpGet:
               path: /ready

--- a/chart/epinio/templates/stage-scripts.yaml
+++ b/chart/epinio/templates/stage-scripts.yaml
@@ -4,6 +4,9 @@ metadata:
   name: epinio-stage-scripts
   namespace: {{ .Release.Namespace }}
 data:
+  builderImage:  "{{ template "registry-url" . }}{{ .Values.image.builder.repository}}:{{ .Values.image.builder.tag }}"
+  downloadImage: "{{ template "registry-url" . }}{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
+  unpackImage:   "{{ template "registry-url" . }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
   download: |-
     # Parameters
     # - PROTOCOL # s3 protocol

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -10,7 +10,8 @@ email: "epinio@suse.com"
 registryURL: ""
 image:
   epinio:
-    repository: ghcr.io/epinio/epinio-server
+    registry: ghcr.io/
+    repository: epinio/epinio-server
     tag: ""
   bash:
     repository: library/bash
@@ -98,7 +99,13 @@ kubed:
 containerregistry:
   enabled: true
 
-  image: registry:2.7.1
+  image:
+    registry:
+      repository: registry
+      tag: 2.7.1
+    nginx:
+      repository: nginx
+      tag: 1.21
   imagePullPolicy: IfNotPresent
 
   # We create a service with type `NodePort` only in

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -21,6 +21,9 @@ image:
   kubectl:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.22.2
+  builder:
+    repository: paketobuildpacks/builder
+    tag: full
 server:
   # Domain which serves the Rancher UI (to access the API)
   accessControlAllowOrigin: ""


### PR DESCRIPTION
Ref https://github.com/epinio/epinio/issues/1305

Provide paketo/awscli/bash image reference, and supply to config map `epinio-stage-scripts`.

See https://github.com/epinio/epinio/pull/1311 for the PR changing the server to consume this information.
