### PR TITLE
Use createNodePort functionality all the time with containerregistry.enabled

### DIFF
--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -44,7 +44,7 @@ spec:
     port: 5000
     targetPort: 5000
 
-{{ if .Values.containerregistry.createNodePort }}
+{{ if .Values.containerregistry.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -104,7 +104,7 @@ spec:
         app.kubernetes.io/instance: "epinio-registry"
     spec:
       containers:
-{{ if .Values.containerregistry.createNodePort }}
+{{ if .Values.containerregistry.enabled }}
       - name: nginx
         image: "{{ template "registry-url" . }}{{ .Values.containerregistry.image.nginx.repository}}:{{ .Values.containerregistry.image.nginx.tag }}"
         imagePullPolicy: IfNotPresent
@@ -179,7 +179,7 @@ spec:
       - name: certs
         secret:
           secretName: epinio-registry-tls
-{{ if .Values.containerregistry.createNodePort }}
+{{ if .Values.containerregistry.enabled }}
       - name: nginx-conf
         configMap:
           name: nginx-conf

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -110,12 +110,6 @@ containerregistry:
       tag: 1.21
   imagePullPolicy: IfNotPresent
 
-  # We create a service with type `NodePort` only in
-  # local deployment as Kubelet cannot access the
-  # secured registry because there is no way to add
-  # registry CA to kubelet.
-  createNodePort: true
-
   # The ingressClassName is used to select the ingress controller. If empty no class will be added to the ingresses.
   ingressClassName: ""
 


### PR DESCRIPTION
and remove the according containerregistry.createNodePort option.

containerregistry.enabled == true means the user gets the NodePort
hack, no other condition needed.
If encrypted communication between kubelet and the registry is
required, then users will have to setup a registry themselves as an
external Epinio registry.