### PR TITLE
Fix epinio docker registry in updatecli config

### DIFF
--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -33,6 +33,7 @@ conditions:
     sourceID: "ui-backend-tag"
     spec:
       image: "ghcr.io/epinio/epinio-ui"
+      architecture: "amd64"
 
 targets:
   epinio-ui-chart:

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -44,8 +44,9 @@ conditions:
     sourceID: "epinio"
     spec:
       image: "ghcr.io/epinio/epinio-server"
+      architecture: "amd64"
 
-  dockerImageContainer:
+  dockerImageRepository:
     name: "Check that ghcr.io/epinio/epinio-server is used in Helm chart epinio"
     kind: "yaml"
     disablesourceinput: true
@@ -53,7 +54,17 @@ conditions:
     spec:
       file: "chart/epinio/values.yaml"
       key: "image.epinio.repository"
-      value: "ghcr.io/epinio/epinio-server"
+      value: "epinio/epinio-server"
+
+  dockerImageRegistry:
+    name: "Check that ghcr.io/epinio/epinio-server is used in Helm chart epinio"
+    kind: "yaml"
+    disablesourceinput: true
+    scmID: "helm-charts"
+    spec:
+      file: "chart/epinio/values.yaml"
+      key: "image.epinio.registry"
+      value: "ghcr.io/"
 
 # Defines what needs to be udpated if needed
 targets:


### PR DESCRIPTION
This PR fix the updatecli pipeline as the values.yaml in epinio helm chart slightly changed.
[Cfr](https://github.com/epinio/helm-charts/runs/5817498970?check_suite_focus=true)

* Fix epinio docker registry in updatecli config
* Specify amd64 architecture in updatecli config
Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>

Local updatecli execution: 

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/.epinio-ui.yaml.swp"
Loading Pipeline "updatecli/updatecli.d/epinio-ui.yaml"
Loading Pipeline "updatecli/updatecli.d/epinio.yaml"

SCM repository retrieved: 2


++++++++++++
+ PIPELINE +
++++++++++++



##########################
# BUMP EPINIO UI VERSION #
##########################


SOURCES
=======

ui-backend-tag
--------------
Searching for version matching pattern "latest"
✔ Git tag "v0.6.0-0.0.1" found matching pattern "latest"


CONDITIONS:
===========

dockerImage
-----------
WARNING: No username and/or password specified: trying to retrieve a token as anonymous user might not be supported or could impact the rate limiting on your network.
✔ The Docker image ghcr.io/epinio/epinio-ui:v0.6.0-0.0.1 exists and is available.


TARGETS
========

epinio-ui-chart
---------------

**Dry Run enabled**

INFO: Using spec.Value instead of source input value.
✔ Key 'epinioUI.image', from file '/tmp/updatecli/epinio/helm-charts/chart/epinio-ui/values.yaml', already set to ghcr.io/epinio/epinio-ui:v0.6.0-0.0.1, nothing else need to be done


PULL REQUESTS
=============



##############################
# BUMP EPINIO SERVER VERSION #
##############################


SOURCES
=======

epinio
------
Searching for version matching pattern "latest"
✔ Github Release version "v0.6.2" found matching pattern "latest"


CHANGELOG:
----------

Release published on the 2022-04-04 13:20:01 +0000 UTC at the url https://github.com/epinio/epinio/releases/tag/v0.6.2


# What's Changed

- Service Catalog (#1322)
- Bump golangci/golangci-lint-action from 2 to 3.1.0 (#1254)
- Add Multi-Arch Image for Epinio Server (#1309)
- Simplify Configuration names and lookup (#1310)
- Pin `mc` (Minio CLI) version (#1304)

## 🚀 Features

- Use createNodePort functionality all the time with containerregistry.enabled (#1326)
- Homebrew bump automation (#1308)

## 🐛 Bug Fixes

- Fix Github permissions (#1334)
- Rancher Marketplace Integration: Import chart CRD changes into development. (#1319)
- Get Staging Support Image References From Kube/Chart (#1311)
- Fix app chart reference for changed configuration lookup (#1317)
- Import epinio chart fix in stage support for zip, etc. (#1303)
- Fix for env variable. (#1301)

## 🧰 Maintenance

- Bump golangci-lint release to 1.45 (#1320)
- Bump go developer version to 1.18 (#1318)
- Fix six dependabot alerts (#1313)
- Fix for env variable. (#1301)
- Namespace cleanup (#1297)

# Usage

More info can be found in the [installation instructions](https://docs.epinio.io/installation/installation.html).



CONDITIONS:
===========

dockerImageRegistry
-------------------
✔ Key "image.epinio.registry", in YAML file "/tmp/updatecli/epinio/helm-charts/chart/epinio/values.yaml", is correctly set to "ghcr.io/"

dockerImageRepository
---------------------
✔ Key "image.epinio.repository", in YAML file "/tmp/updatecli/epinio/helm-charts/chart/epinio/values.yaml", is correctly set to "epinio/epinio-server"

dockerImage
-----------
WARNING: No username and/or password specified: trying to retrieve a token as anonymous user might not be supported or could impact the rate limiting on your network.
✔ The Docker image ghcr.io/epinio/epinio-server:v0.6.2 exists and is available.


TARGETS
========

helm-charts
-----------

**Dry Run enabled**

⚠ Key 'appVersion', from file '/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml', was updated from 'v0.6.1' to 'v0.6.2'


PULL REQUESTS
=============

[Dry Run] A pull request with kind "github" and title "[updatecli] Bump epinio server version" is expected.

=============================

REPORTS:


✔ EPINIO-UI.YAML:
	Sources:
		✔ [ui-backend-tag] Get latest Epinio UI backend git tag (kind: gittag)
	Condition:
		✔ [dockerImage] Check that ghcr.io/epinio/epinio-ui:v0.6.0-0.0.1 exists (kind: dockerImage)
	Target:
		✔ [epinio-ui-chart] Update Epinio UI backend image for Helm Chart chart/epinio-ui (kind: helmChart)



⚠ EPINIO.YAML:
	Sources:
		✔ [epinio] Get Latest epinio version (kind: githubRelease)
	Condition:
		✔ [dockerImage] Check that ghcr.io/epinio/epinio-server:v0.6.2 is published (kind: dockerImage)
		✔ [dockerImageRegistry] Check that ghcr.io/epinio/epinio-server is used in Helm chart epinio (kind: yaml)
		✔ [dockerImageRepository] Check that ghcr.io/epinio/epinio-server is used in Helm chart epinio (kind: yaml)
	Target:
		⚠ [helm-charts] Update epinio version in chart epinio (kind: helmChart)



Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
  * Total:	2
```