### PR TITLE
Fix for invalid name

### DIFF
--- a/chart/application/templates/_helpers.tpl
+++ b/chart/application/templates/_helpers.tpl
@@ -29,5 +29,5 @@ Resource name truncation while keeping it unique. Keep as-is when short enough.
 Else compute a 32-char hash and affix it to the suitably truncated base.
 */}}
 {{- define "epinio-truncate" -}}
-{{ ternary . (print (trunc 30 .) "-" (trunc 31 (sha256sum .))) (lt (len .) 64) }}
+{{ ternary . (print (trunc 30 .) (trunc 32 (sha256sum .))) (lt (len .) 64) }}
 {{- end }}


### PR DESCRIPTION
Fix for [#1341](https://github.com/epinio/epinio/issues/1341) 

This is a quick fix for the issue above, but we should probably rethink about how we name things.