### PR TITLE
New default users

### DIFF
--- a/chart/epinio/templates/default-user.yaml
+++ b/chart/epinio/templates/default-user.yaml
@@ -25,4 +25,3 @@ stringData:
   password: password
   namespaces: |
     workspace
-    workspace2

--- a/chart/epinio/templates/default-user.yaml
+++ b/chart/epinio/templates/default-user.yaml
@@ -4,8 +4,25 @@ type: BasicAuth
 metadata:
   labels:
     epinio.suse.org/api-user-credentials: "true"
+    epinio.suse.org/role: "admin"
+  name: admin-epinio-user
+  namespace: {{ .Release.Namespace }}
+stringData:
+  username: {{ .Values.api.username }}
+  password: {{ .Values.api.password }}
+---
+apiVersion: v1
+kind: Secret
+type: BasicAuth
+metadata:
+  labels:
+    epinio.suse.org/api-user-credentials: "true"
+    epinio.suse.org/role: "namespaced-user"
   name: default-epinio-user
   namespace: {{ .Release.Namespace }}
 stringData:
-  password: {{ .Values.api.password }}
-  username: {{ .Values.api.username }}
+  username: epinio
+  password: password
+  namespaces: |
+    workspace
+    workspace2


### PR DESCRIPTION
This PR adds one user and some metadata.

So now we have a `epinio.suse.org/role` label that will define the role of the user, and we have an `admin` and `namespaced-user` role (if you have a better name for this role please tell me!).

For the `namespaced-user` role we should have also a `namespaces` attribute, with a list of namespaces.
I choosed to use a secret attribute for two reasons:
1. label values are limited in length: hard limit on 63 chars, so not many namespaces to assign
2. label values are limited in characters: the only possible delimiter is the `-`, so it's impossible to distinguish from the correct name

It's also easier to add/edit the list in this way, and the newline separator makes it possible to have any kind of characters, and a cleaner view of the namespaces.