### PR TITLE
Remove unecessary prefixes from resource names

### DIFF
--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.15
+version: 0.1.16
 keywords:
 - epinio
 - paas

--- a/chart/application/templates/_helpers.tpl
+++ b/chart/application/templates/_helpers.tpl
@@ -24,10 +24,21 @@ app.kubernetes.io/name: {{ .Values.epinio.appName }}
 app.kubernetes.io/component: application
 {{- end }}
 
+
 {{/*
-Resource name truncation while keeping it unique. Keep as-is when short enough.
-Else compute a 32-char hash and affix it to the suitably truncated base.
+Remove character that are invalid for kubernetes resource names from the
+given string
+*/}}
+{{- define "epinio-name-sanitize" -}}
+{{ regexReplaceAll "[^-a-z0-9]*" . "" }}
+{{- end }}
+
+{{/*
+Resource name sanitization and truncation.
+Always suffix the sha1sum (40 characters long)
+The rest of the character up to 63 is the original string with invalid
+character removed.
 */}}
 {{- define "epinio-truncate" -}}
-{{ ternary . (print (trunc 30 .) (trunc 32 (sha256sum .))) (lt (len .) 64) }}
+{{ print (trunc 22 (include "epinio-name-sanitize" .)) "-" (sha1sum .) }}
 {{- end }}

--- a/chart/application/templates/ingress.yaml
+++ b/chart/application/templates/ingress.yaml
@@ -3,11 +3,11 @@
 apiVersion: "cert-manager.io/v1"
 kind: Certificate
 metadata:
-  name: {{ include "epinio-truncate" (print "i-" $.Values.epinio.appName "-" .id) }}
+  name: {{ include "epinio-truncate" (print $.Values.epinio.appName "-" .id) }}
   labels:
     {{- include "epinio-application.labels" $ | nindent 4 }}
 spec:
-  secretName: {{ include "epinio-truncate" (print "i-" $.Values.epinio.appName "-" .id "-tls") }}
+  secretName: {{ include "epinio-truncate" (print $.Values.epinio.appName "-" .id "-tls") }}
   dnsNames:
   - {{ .domain }}
   issuerRef:
@@ -17,7 +17,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "epinio-truncate" (print "i-" $.Values.epinio.appName "-" .id) }}
+  name: {{ include "epinio-truncate" (print $.Values.epinio.appName "-" .id) }}
   namespace: {{ $.Release.Namespace }}
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
@@ -34,7 +34,7 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ include "epinio-truncate" (print "s-" $.Values.epinio.appName) }}
+                name: {{ include "epinio-truncate" (print $.Values.epinio.appName) }}
                 port:
                   number: 8080
             path: {{ .path | quote }}
@@ -42,5 +42,5 @@ spec:
   tls:
     - hosts:
       - {{ .domain | quote }}
-      secretName: {{ include "epinio-truncate" (print "i-" $.Values.epinio.appName "-" .id "-tls") }}
+      secretName: {{ include "epinio-truncate" (print $.Values.epinio.appName "-" .id "-tls") }}
 {{- end }}

--- a/chart/application/templates/service.yaml
+++ b/chart/application/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.tls: "true"
   labels:
     {{- include "epinio-application.labels" . | nindent 4 }}
-  name: {{ include "epinio-truncate" (print "s-" .Values.epinio.appName) }}
+  name: {{ include "epinio-truncate" (print .Values.epinio.appName) }}
   namespace:  {{ .Release.Namespace }}
 spec:
   ports:


### PR DESCRIPTION
we know it's an Ingress, no need to prefix it with `i-`

Part of: https://github.com/epinio/epinio/issues/1370

Sibling PR: https://github.com/epinio/epinio/pull/1422