### PR TITLE
Automate Epinio dependencies update

### DIFF
--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -42,7 +42,7 @@ targets:
     scmID: "helm-charts"
     sourceID: "ui-backend-tag"
     transformers:
-      - addPrefix: "ghcr.io/epinio/epinio-ui:"
+      - addprefix: "ghcr.io/epinio/epinio-ui:"
     spec:
       name: "chart/epinio-ui"
       file: "values.yaml"

--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -24,13 +24,13 @@ sources:
   ui-backend-tag:
     name: "Get latest Epinio UI backend git tag"
     kind: "gittag"
-    scmID: ui-backend
+    scmid: ui-backend
 
 conditions:
   dockerImage:
     name: 'Check that ghcr.io/epinio/epinio-ui:{{ source "ui-backend-tag" }} exists'
     kind: "dockerImage"
-    sourceID: "ui-backend-tag"
+    sourceid: "ui-backend-tag"
     spec:
       image: "ghcr.io/epinio/epinio-ui"
       architecture: "amd64"
@@ -39,8 +39,8 @@ targets:
   epinio-ui-chart:
     name: "Update Epinio UI backend image for Helm Chart chart/epinio-ui"
     kind: "helmChart"
-    scmID: "helm-charts"
-    sourceID: "ui-backend-tag"
+    scmid: "helm-charts"
+    sourceid: "ui-backend-tag"
     transformers:
       - addprefix: "ghcr.io/epinio/epinio-ui:"
     spec:

--- a/updatecli/updatecli.d/epinio/epinio.yaml
+++ b/updatecli/updatecli.d/epinio/epinio.yaml
@@ -17,7 +17,7 @@ scms:
 pullrequests:
   helm-charts:
     kind: "github"
-    scmID: "helm-charts"
+    scmid: "helm-charts"
     targets:
       - "helm-charts"
     spec:
@@ -29,7 +29,7 @@ pullrequests:
 sources:
   epinio:
     name: "Get Latest epinio version"
-    kind: "githubRelease"
+    kind: "githubrelease"
     spec:
       owner: "epinio"
       repository: "epinio"
@@ -40,8 +40,8 @@ sources:
 conditions:
   dockerImage:
     name: 'Check that ghcr.io/epinio/epinio-server:{{ source "epinio" }} is published'
-    kind: "dockerImage"
-    sourceID: "epinio"
+    kind: "dockerimage"
+    sourceid: "epinio"
     spec:
       image: "ghcr.io/epinio/epinio-server"
       architecture: "amd64"
@@ -50,7 +50,7 @@ conditions:
     name: "Check that container image repository 'epinio/epinio-server' is used in Helm chart epinio"
     kind: "yaml"
     disablesourceinput: true
-    scmID: "helm-charts"
+    scmid: "helm-charts"
     spec:
       file: "chart/epinio/values.yaml"
       key: "image.epinio.repository"
@@ -60,7 +60,7 @@ conditions:
     name: "Check that 'ghcr.io' registry is used in Helm chart epinio"
     kind: "yaml"
     disablesourceinput: true
-    scmID: "helm-charts"
+    scmid: "helm-charts"
     spec:
       file: "chart/epinio/values.yaml"
       key: "image.epinio.registry"
@@ -70,11 +70,12 @@ conditions:
 targets:
   helm-charts:
     name: "Update epinio version in chart epinio"
-    kind: "helmChart"
-    scmID: "helm-charts"
-    sourceID: "epinio"
+    kind: "helmchart"
+    scmid: "helm-charts"
+    sourceid: "epinio"
     spec:
       name: "chart/epinio"
       file: "Chart.yaml"
       key: "appVersion"
-      versionIncrement: minor
+      versionincrement: minor
+

--- a/updatecli/updatecli.d/epinio/epinioui.yaml
+++ b/updatecli/updatecli.d/epinio/epinioui.yaml
@@ -1,0 +1,60 @@
+---
+title: "Bump the Epinio chart depedency 'epinio-io'"
+# Define git repository configuration to know where to push changes
+scms:
+  default:
+    kind: "github"
+    spec:
+      user: "{{ .github.epinio.user }}"
+      email: "{{ .github.epinio.email }}"
+      owner: "{{ .github.epinio.owner }}"
+      repository: "{{ .github.epinio.repository }}"
+      token: '{{ requiredEnv .github.epinio.token }}'
+      username: "{{ .github.epinio.username }}"
+      branch: "{{ .github.epinio.branch }}"
+
+# Define pullrequest configuration if one needs to be created
+pullrequests:
+  helm-charts:
+    kind: "github"
+    scmid: "default"
+    targets:
+      - "chart"
+    spec:
+      labels:
+        - "dependencies"
+        - "epinio"
+
+# Defines where we get source values
+sources:
+  epinioui:
+    name: "Get Latest epinio-ui helm chart version"
+    kind: "helmchart"
+    spec:
+      url:  https://epinio.github.io/helm-charts
+      name: epinio-ui
+
+conditions:
+  epinio:
+    kind: yaml
+    name: "Test Epinio Helm Chart dependency containing epinio-ui"
+    disablesourceinput: true
+    scmid: default
+    spec:
+      file: "chart/epinio/Chart.yaml"
+      key: "dependencies[2].name"
+      value: epinio-ui
+
+# Defines what needs to be udpated if needed
+targets:
+  chart:
+    name: "Update Epinio Helm Chart dependency to the latest epinio-ui chart version"
+    kind: "helmchart"
+    scmid: "default"
+    sourceid: "epinioui"
+    spec:
+      name: "chart/epinio"
+      file: "Chart.yaml"
+      key: "dependencies[2].version"
+      versionincrement: minor
+

--- a/updatecli/updatecli.d/epinio/kubed.yaml
+++ b/updatecli/updatecli.d/epinio/kubed.yaml
@@ -1,0 +1,65 @@
+---
+title: "Bump the Epinio chart dependency 'kubed'"
+# Define git repository configuration to know where to push changes
+scms:
+  default:
+    kind: "github"
+    spec:
+      user: "{{ .github.epinio.user }}"
+      email: "{{ .github.epinio.email }}"
+      owner: "{{ .github.epinio.owner }}"
+      repository: "{{ .github.epinio.repository }}"
+      token: '{{ requiredEnv .github.epinio.token }}'
+      username: "{{ .github.epinio.username }}"
+      branch: "{{ .github.epinio.branch }}"
+
+# Define pullrequest configuration if one needs to be created
+pullrequests:
+  helm-charts:
+    kind: "github"
+    scmid: "default"
+    targets:
+      - "chart"
+    spec:
+      labels:
+        - "dependencies"
+        - "epinio"
+
+# Defines where we get source values
+sources:
+  kubed:
+    name: "Get Latest Kubed Helm Chart version"
+    kind: "helmchart"
+    spec:
+      # Doesn't work :/
+      #url: "https://charts.appscode.com/stable/"
+      url: "https://charts.appscode.com/stable"
+      name: "kubed"
+    # Ensure that the version doesn't start with v
+    transformers:
+      - trimprefix: v
+
+conditions:
+  epinio:
+    kind: yaml
+    name: "Ensure Kubed is defined in Epinio chart dependency"
+    disablesourceinput: true
+    scmid: default
+    spec:
+      file: "chart/epinio/Chart.yaml"
+      key: "dependencies[1].name"
+      value: kubed
+
+# Defines what needs to be udpated if needed
+targets:
+  chart:
+    name: "Update Epinio Helm chart dependency to latest Kubed version"
+    kind: "helmchart"
+    scmid: "default"
+    sourceid: "kubed"
+    spec:
+      name: "chart/epinio"
+      file: "Chart.yaml"
+      key: "dependencies[1].version"
+      versionincrement: minor
+

--- a/updatecli/updatecli.d/epinio/minio.yaml
+++ b/updatecli/updatecli.d/epinio/minio.yaml
@@ -1,0 +1,60 @@
+---
+title: "Bump the Epinio chart dependency 'minio'"
+# Define git repository configuration to know where to push changes
+scms:
+  default:
+    kind: "github"
+    spec:
+      user: "{{ .github.epinio.user }}"
+      email: "{{ .github.epinio.email }}"
+      owner: "{{ .github.epinio.owner }}"
+      repository: "{{ .github.epinio.repository }}"
+      token: '{{ requiredEnv .github.epinio.token }}'
+      username: "{{ .github.epinio.username }}"
+      branch: "{{ .github.epinio.branch }}"
+
+# Define pullrequest configuration if one needs to be created
+pullrequests:
+  helm-charts:
+    kind: "github"
+    scmid: "default"
+    targets:
+      - "chart"
+    spec:
+      labels:
+        - "dependencies"
+        - "epinio"
+
+# Defines where we get source values
+sources:
+  minio:
+    name: "Get Latest minio Helm Chart version"
+    kind: "helmchart"
+    spec:
+      url:  https://charts.min.io/
+      name: minio
+
+conditions:
+  epinio:
+    kind: yaml
+    name: "Ensure minio is defined in Epinio chart dependency"
+    disablesourceinput: true
+    scmid: default
+    spec:
+      file: "chart/epinio/Chart.yaml"
+      key: "dependencies[0].name"
+      value: minio
+
+# Defines what needs to be udpated if needed
+targets:
+  chart:
+    name: "Update Epinio chart dependency to latest minio version"
+    kind: "helmchart"
+    scmid: "default"
+    sourceid: "minio"
+    spec:
+      name: "chart/epinio"
+      file: "Chart.yaml"
+      key: "dependencies[0].version"
+      versionincrement: minor
+


### PR DESCRIPTION
# Automate Epinio dependencies update

Fix #189 

Depends on [updatecli/updatecli#680](https://github.com/updatecli/updatecli/pull/680)

Here is an example of the updatecli run locally using 

`updatecli diff --config updatecli/updatecli.d/epinio/ --values updatecli/values.yaml `

<details><summary>Updatecli Diff Example - Click to expand</summary>
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/epinio/epinio.yaml"
Loading Pipeline "updatecli/updatecli.d/epinio/epinioui.yaml"
Loading Pipeline "updatecli/updatecli.d/epinio/kubed.yaml"
Loading Pipeline "updatecli/updatecli.d/epinio/minio.yaml"

SCM repository retrieved: 1


++++++++++++
+ PIPELINE    +
++++++++++++



##############################
# BUMP EPINIO SERVER VERSION #
##############################


SOURCES
=======

epinio
------
Searching for version matching pattern "latest"
✔ Github Release version "v0.7.1" found matching pattern "latest"


CHANGELOG:
----------

Release published on the 2022-04-19 14:20:10 +0000 UTC at the url https://github.com/epinio/epinio/releases/tag/v0.7.1

# What's Changed

- Epinio Services (#1357, #1349, #1354, #1350, #1355)

# Usage

https://docs.epinio.io/references/services.html



CONDITIONS:
===========

dockerImage
-----------
WARNING: No username and/or password specified: trying to retrieve a token as anonymous user might not be supported or could impact the rate limiting on your network.
✔ The Docker image ghcr.io/epinio/epinio-server:v0.7.1 exists and is available.

dockerImageRegistry
-------------------
✔ Key "image.epinio.registry", in YAML file "/tmp/updatecli/epinio/helm-charts/chart/epinio/values.yaml", is correctly set to "ghcr.io/"

dockerImageRepository
---------------------
✔ Key "image.epinio.repository", in YAML file "/tmp/updatecli/epinio/helm-charts/chart/epinio/values.yaml", is correctly set to "epinio/epinio-server"


TARGETS
========

helm-charts
-----------

**Dry Run enabled**

✔ Key 'appVersion', from file '/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml', already set to v0.7.1, nothing else need to be done


PULL REQUESTS
=============



###############################################
# BUMP THE EPINIO CHART DEPEDENCY 'EPINIO-IO' #
###############################################


SOURCES
=======

epinioui
--------
✔ Helm Chart 'epinio-ui' version '0.2.0' is found from repository https://epinio.github.io/helm-charts

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: epinio-ui
A Helm chart for the Epinio UI
Project Home: https://github.com/epinio/epinio

Version created on the 2022-04-11 13:48:11.014338391 &#43;0000 UTC

Sources:

* https://github.com/epinio/ui



URL:

* https://github.com/epinio/helm-charts/releases/download/epinio-ui-0.2.0/epinio-ui-0.2.0.tgz




CHANGELOG:
----------

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: epinio-ui
A Helm chart for the Epinio UI
Project Home: https://github.com/epinio/epinio

Version created on the 2022-04-11 13:48:11.014338391 &#43;0000 UTC

Sources:

* https://github.com/epinio/ui



URL:

* https://github.com/epinio/helm-charts/releases/download/epinio-ui-0.2.0/epinio-ui-0.2.0.tgz





CONDITIONS:
===========

epinio
------
✔ Key "dependencies[2].name", in YAML file "/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml", is correctly set to "epinio-ui"


TARGETS
========

chart
-----

**Dry Run enabled**

✔ Key 'dependencies[2].version', from file '/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml', already set to 0.2.0, nothing else need to be done


PULL REQUESTS
=============



############################################
# BUMP THE EPINIO CHART DEPENDENCY 'KUBED' #
############################################


SOURCES
=======

kubed
-----
✔ Helm Chart 'kubed' version 'v0.13.2' is found from repository https://charts.appscode.com/stable

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: kubed
Config Syncer by AppsCode - Kubernetes daemon
Project Home: https://github.com/kubeops/config-syncer

Version created on the 2022-02-24 17:48:29.779247147 &#43;0000 UTC

Sources:

* https://github.com/kubeops/config-syncer



URL:

* https://charts.appscode.com/stable/kubed/kubed-v0.13.2.tgz




CHANGELOG:
----------

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: kubed
Config Syncer by AppsCode - Kubernetes daemon
Project Home: https://github.com/kubeops/config-syncer

Version created on the 2022-02-24 17:48:29.779247147 &#43;0000 UTC

Sources:

* https://github.com/kubeops/config-syncer



URL:

* https://charts.appscode.com/stable/kubed/kubed-v0.13.2.tgz





CONDITIONS:
===========

epinio
------
✔ Key "dependencies[1].name", in YAML file "/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml", is correctly set to "kubed"


TARGETS
========

chart
-----

**Dry Run enabled**

✔ Key 'dependencies[1].version', from file '/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml', already set to 0.13.2, nothing else need to be done


PULL REQUESTS
=============



############################################
# BUMP THE EPINIO CHART DEPENDENCY 'MINIO' #
############################################


SOURCES
=======

minio
-----
✔ Helm Chart 'minio' version '4.0.1' is found from repository https://charts.min.io/

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: minio
Multi-Cloud Object Storage
Project Home: https://min.io

Version created on the 2022-05-01 23:09:59.936663591 -0700 -0700

Sources:

* https://github.com/minio/minio



URL:

* https://charts.min.io/helm-releases/minio-4.0.1.tgz




CHANGELOG:
----------

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: minio
Multi-Cloud Object Storage
Project Home: https://min.io

Version created on the 2022-05-01 23:09:59.936663591 -0700 -0700

Sources:

* https://github.com/minio/minio



URL:

* https://charts.min.io/helm-releases/minio-4.0.1.tgz





CONDITIONS:
===========

epinio
------
✔ Key "dependencies[0].name", in YAML file "/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml", is correctly set to "minio"


TARGETS
========

chart
-----

**Dry Run enabled**

⚠ Key 'dependencies[0].version', from file '/tmp/updatecli/epinio/helm-charts/chart/epinio/Chart.yaml', was updated from '3.6.3' to '4.0.1'
	Chart Version updated from "0.9.1" to "0.10.0"


PULL REQUESTS
=============

[Dry Run] A pull request with kind "github" and title "[updatecli] Bump the Epinio chart dependency 'minio'" is expected.

=============================

REPORTS:


✔ EPINIO.YAML:
	Sources:
		✔ [epinio] Get Latest epinio version (kind: githubrelease)
	Condition:
		✔ [dockerImage] Check that ghcr.io/epinio/epinio-server:v0.7.1 is published (kind: dockerimage)
		✔ [dockerImageRegistry] Check that 'ghcr.io' registry is used in Helm chart epinio (kind: yaml)
		✔ [dockerImageRepository] Check that container image repository 'epinio/epinio-server' is used in Helm chart epinio (kind: yaml)
	Target:
		✔ [helm-charts] Update epinio version in chart epinio (kind: helmchart)



✔ EPINIOUI.YAML:
	Sources:
		✔ [epinioui] Get Latest epinio-ui helm chart version (kind: helmchart)
	Condition:
		✔ [epinio] Test Epinio Helm Chart dependency containing epinio-ui (kind: yaml)
	Target:
		✔ [chart] Update Epinio Helm Chart dependency to the latest epinio-ui chart version (kind: helmchart)



✔ KUBED.YAML:
	Sources:
		✔ [kubed] Get Latest Kubed Helm Chart version (kind: helmchart)
	Condition:
		✔ [epinio] Ensure Kubed is defined in Epinio chart dependency (kind: yaml)
	Target:
		✔ [chart] Update Epinio Helm chart dependency to latest Kubed version (kind: helmchart)



⚠ MINIO.YAML:
	Sources:
		✔ [minio] Get Latest minio Helm Chart version (kind: helmchart)
	Condition:
		✔ [epinio] Ensure minio is defined in Epinio chart dependency (kind: yaml)
	Target:
		⚠ [chart] Update Epinio chart dependency to latest minio version (kind: helmchart)



Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	3
  * Total:	4

</details>