### PR TITLE
Remove leading digits from resource names

### DIFF
--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.16
+version: 0.1.17
 keywords:
 - epinio
 - paas

--- a/chart/application/templates/_helpers.tpl
+++ b/chart/application/templates/_helpers.tpl
@@ -24,9 +24,8 @@ app.kubernetes.io/name: {{ .Values.epinio.appName }}
 app.kubernetes.io/component: application
 {{- end }}
 
-
 {{/*
-Remove character that are invalid for kubernetes resource names from the
+Removes character that are invalid for kubernetes resource names from the
 given string
 */}}
 {{- define "epinio-name-sanitize" -}}
@@ -35,10 +34,11 @@ given string
 
 {{/*
 Resource name sanitization and truncation.
-Always suffix the sha1sum (40 characters long)
-The rest of the character up to 63 is the original string with invalid
+- Always suffix the sha1sum (40 characters long)
+- Always add an "r" prefix to make sure we don't have leading digits
+- The rest of the character up to 63 is the original string with invalid
 character removed.
 */}}
 {{- define "epinio-truncate" -}}
-{{ print (trunc 22 (include "epinio-name-sanitize" .)) "-" (sha1sum .) }}
+{{ print "r" (trunc 21 (include "epinio-name-sanitize" .)) "-" (sha1sum .) }}
 {{- end }}

--- a/chart/application/templates/_helpers.tpl
+++ b/chart/application/templates/_helpers.tpl
@@ -25,7 +25,7 @@ app.kubernetes.io/component: application
 {{- end }}
 
 {{/*
-Removes character that are invalid for kubernetes resource names from the
+Removes characters that are invalid for kubernetes resource names from the
 given string
 */}}
 {{- define "epinio-name-sanitize" -}}
@@ -36,7 +36,7 @@ given string
 Resource name sanitization and truncation.
 - Always suffix the sha1sum (40 characters long)
 - Always add an "r" prefix to make sure we don't have leading digits
-- The rest of the character up to 63 is the original string with invalid
+- The rest of the characters up to 63 are the original string with invalid
 character removed.
 */}}
 {{- define "epinio-truncate" -}}

--- a/chart/epinio/templates/default-app-chart.yaml
+++ b/chart/epinio/templates/default-app-chart.yaml
@@ -12,4 +12,4 @@ metadata:
 spec:
   shortDescription: Epinio standard deployment
   description: Epinio standard support chart for application deployment
-  helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.16/epinio-application-0.1.16.tgz
+  helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.17/epinio-application-0.1.17.tgz


### PR DESCRIPTION
Fixing the problem that was introduced here: https://github.com/epinio/helm-charts/pull/187/files

We used to add prefixes like `i-` for Ingress and such so we didn't get leading digits. We will now just remove the leading digits.