### PR TITLE
Pinning the dev/demo services to specific chart versions.

### DIFF
--- a/chart/epinio/templates/service-catalog.yaml
+++ b/chart/epinio/templates/service-catalog.yaml
@@ -14,7 +14,7 @@ spec:
     You can find more info at https://github.com/bitnami/charts/tree/master/bitnami/postgresql/.
     This database is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
-  chart: postgresql
+  chart: postgresql:11.1.28
   helmRepo:
     name: bitnami
     url: "https://charts.bitnami.com/bitnami"
@@ -33,7 +33,7 @@ spec:
     You can find more info at https://github.com/bitnami/charts/tree/master/bitnami/mysql/.
     This database is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
-  chart: mysql
+  chart: mysql:8.9.6
   helmRepo:
     name: bitnami
     url: "https://charts.bitnami.com/bitnami"
@@ -52,7 +52,7 @@ spec:
     You can find more info at https://github.com/bitnami/charts/tree/master/bitnami/redis/.
     This database is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
-  chart: redis
+  chart: redis:16.9.1
   helmRepo:
     name: bitnami
     url: "https://charts.bitnami.com/bitnami"
@@ -71,7 +71,7 @@ spec:
     You can find more info at https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq/.
     This instance is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
-  chart: rabbitmq
+  chart: rabbitmq:9.0.3
   helmRepo:
     name: bitnami
     url: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Ref https://github.com/epinio/epinio/issues/1363

Pinning the dev/demo services to specific chart versions.

Requires https://github.com/epinio/epinio/pull/1435 to work. An older epinio binary will not properly pass the version information added here into the helm chart CR, breaking deployment.
