### PR TITLE
Helm Controller and CRDs

### DIFF
--- a/chart/epinio/templates/helm-controller.yaml
+++ b/chart/epinio/templates/helm-controller.yaml
@@ -1,7 +1,4 @@
-{{- if and
-      (not (.Capabilities.APIVersions.Has "helmcharts.helm.cattle.io/v1"))
-      (not (.Capabilities.APIVersions.Has "helmchartconfigs.helm.cattle.io/v1"))
--}}
+{{- if not (.Capabilities.APIVersions.Has "helm.cattle.io/v1") -}}
 
 # Helm Controller Deployment
 ---

--- a/chart/epinio/templates/helm-controller.yaml
+++ b/chart/epinio/templates/helm-controller.yaml
@@ -24,44 +24,6 @@ spec:
           image: rancher/helm-controller:v0.12.1
           command: ["helm-controller"]
 
-# RBAC - ClusterRoleBinding
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: helm-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: helm-controller
-subjects:
-- kind: ServiceAccount
-  name: helm-controller
-  namespace: {{ .Release.Namespace }}
-
-# RBAC - ServiceAccount
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: helm-controller
-  namespace: {{ .Release.Namespace }}
-
-# RBAC - ClusterRole auth
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: helm-controller
-rules:
-- apiGroups:
-  - helm.cattle.io
-  resources:
-  - helmchartconfigs
-  - helmcharts
-  verbs:
-  - list
-
 # HelmChart CRD
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/chart/epinio/templates/helm-controller.yaml
+++ b/chart/epinio/templates/helm-controller.yaml
@@ -1,12 +1,36 @@
 {{- if not (.Capabilities.APIVersions.Has "helm.cattle.io/v1") -}}
 
+# RBAC - ServiceAccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: helm-controller
+  namespace: {{ .Release.Namespace }}
+
+
+# RBAC - ClusterRoleBinding
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: helm-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: helm-controller
+  namespace: {{ .Release.Namespace }}
+
 # Helm Controller Deployment
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: helm-controller
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: helm-controller
 spec:
@@ -19,6 +43,7 @@ spec:
       labels:
         app: helm-controller
     spec:
+      serviceAccountName: helm-controller
       containers:
         - name: helm-controller
           image: rancher/helm-controller:v0.12.1

--- a/chart/epinio/templates/helm-controller.yaml
+++ b/chart/epinio/templates/helm-controller.yaml
@@ -1,0 +1,196 @@
+{{- if and
+      (not (.Capabilities.APIVersions.Has "helmcharts.helm.cattle.io/v1"))
+      (not (.Capabilities.APIVersions.Has "helmchartconfigs.helm.cattle.io/v1"))
+-}}
+
+# Helm Controller Deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-controller
+  namespace: kube-system
+  labels:
+    app: helm-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helm-controller
+  template:
+    metadata:
+      labels:
+        app: helm-controller
+    spec:
+      containers:
+        - name: helm-controller
+          image: rancher/helm-controller:v0.12.1
+          command: ["helm-controller"]
+
+# RBAC - ClusterRoleBinding
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: helm-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: helm-controller
+subjects:
+- kind: ServiceAccount
+  name: helm-controller
+  namespace: {{ .Release.Namespace }}
+
+# RBAC - ServiceAccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: helm-controller
+  namespace: {{ .Release.Namespace }}
+
+# RBAC - ClusterRole auth
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: helm-controller
+rules:
+- apiGroups:
+  - helm.cattle.io
+  resources:
+  - helmchartconfigs
+  - helmcharts
+  verbs:
+  - list
+
+# HelmChart CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: helmcharts.helm.cattle.io
+spec:
+  group: helm.cattle.io
+  names:
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
+    singular: helmchart
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              bootstrap:
+                type: boolean
+              chart:
+                type: string
+              chartContent:
+                type: string
+              failurePolicy:
+                type: string
+              helmVersion:
+                type: string
+              jobImage:
+                type: string
+              repo:
+                type: string
+              repoCA:
+                type: string
+              set:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                type: object
+              targetNamespace:
+                type: string
+              timeout:
+                type: string
+              valuesContent:
+                type: string
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              jobName:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+# HelmChartConfig CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: helmchartconfigs.helm.cattle.io
+spec:
+  group: helm.cattle.io
+  names:
+    kind: HelmChartConfig
+    listKind: HelmChartConfigList
+    plural: helmchartconfigs
+    singular: helmchartconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              failurePolicy:
+                type: string
+              valuesContent:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+{{- end -}}


### PR DESCRIPTION
#### Issue
- https://github.com/epinio/epinio/issues/1398
---

This PR adds the Helm Controller in clusters without it already installed.

The `helm-controller` will be installed if the two CRDs are missing.
The HelmChart and HelmChartConfig were generated from the [k3s-io/helm-controller](https://github.com/k3s-io/helm-controller) repo, with `controller-gen` (the original CRDs in the repo are too old):

```
controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
controller-gen "crd:trivialVersions=true,preserveUnknownFields=false" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
```

The `helm-controller` will be deployed in the `kube-system` namespace. I've tried to deploy it in a different one (such as `epinio`) and it worked, but I had to give to it very large permissions (probably the same that it has in the `kube-system`).

I got this error while trying to tune the minimum set of permissions:

```
user "system:serviceaccount:epinio:helm-controller" (groups=["system:serviceaccounts" "system:serviceaccounts:epinio"  "system:authenticated"])
is attempting to grant RBAC permissions not currently held:
{
  APIGroups: ["*"],
  Resources:["*"],
  Verbs:["*"]
}
{
  NonResourceURLs: ["*"],
  Verbs: ["*"]
}  
```

so it needs to do everything everywhere. This is because Helm doesn't know in advance what kind of resources it needs to create.

Anyway, if we want to deploy it in the `epinio` namespace we just need to set the namespace and the service account in the Deployment:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: helm-controller
  namespace: {{ .Release.Namespace }}
spec:
  template:
    spec:
      serviceAccountName: helm-controller
```
and then the ClusterRole, ServiceAccount and ClusterRoleBinding:
```yaml
# RBAC - ClusterRoleBinding
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: helm-controller
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: helm-controller
subjects:
- kind: ServiceAccount
  name: helm-controller
  namespace: {{ .Release.Namespace }}

# RBAC - ServiceAccount
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: helm-controller
  namespace: {{ .Release.Namespace }}

# RBAC - ClusterRole auth
---
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: helm-controller
rules:
- apiGroups: ["*"]
  resources: ["*"]
  verbs: ["*"]
```