### PR TITLE
Ensure UI makes use of custom domain with CORS

### DIFF
--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -37,6 +37,8 @@ spec:
         workingDir: /db
 
         env:
+        - name: ALLOWED_ORIGINS
+          value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioAllowedOrigins }}
         - name: EPINIO_API_URL
           value: {{ default (printf "http://epinio-server.%s.svc.cluster.local" .Release.Namespace) .Values.epinioApiUrl }}
         - name: EPINIO_WSS_URL

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -15,6 +15,8 @@ logLevel: info
 # API URL of epinio instance, for proxied connections, defaults to http://epinio-server.%s.svc.cluster.local"
 epinioApiUrl: ""
 epinioWssUrl: ""
+# Domain that will serve the UI and be the origin of browser requests, used by CORS process
+epinioAllowedOrigins: ""
 # Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`
 epinioApiSkipSSL: "true"
 # This is the version that is displayed in the ui and should match that of the epinio it's targetting


### PR DESCRIPTION
- Wire in custom domain to the ui-backend by setting ALLOW_ORIGINS
- See https://github.com/epinio/ui-backend/blob/main/src/jetstream/main.go#L830
- Related issue - https://github.com/epinio/ui/issues/96