### PR TITLE
Use Bcrypt for passwords

### DIFF
--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -57,9 +57,9 @@ questions:
   type: strings
   required: false
   group: "General settings"
-- variable: api.password
+- variable: api.passwordBcrypt
   label: API password
-  description: "The password for authenticating all API requests"
+  description: "The password for authenticating all API requests (hashed with Bcrypt)"
   type: password
   required: false
   group: "General settings"

--- a/chart/epinio/templates/NOTES.txt
+++ b/chart/epinio/templates/NOTES.txt
@@ -1,8 +1,8 @@
 To interract with your Epinio installation download the latest epinio binary from https://github.com/epinio/epinio/releases/latest.
 
-Update the api location and credentials with:
+Login to the cluster with:
     
-    `epinio settings update`
+    `epinio login -u admin -p password https://epinio.{{ .Values.global.domain }}`
 
 or go to the dashboard at: https://epinio.{{ .Values.global.domain }}
 

--- a/chart/epinio/templates/NOTES.txt
+++ b/chart/epinio/templates/NOTES.txt
@@ -2,8 +2,10 @@ To interract with your Epinio installation download the latest epinio binary fro
 
 Login to the cluster with:
     
-    `epinio login -u admin -p password https://epinio.{{ .Values.global.domain }}`
+    `epinio login -u {{.Values.api.username}} https://epinio.{{ .Values.global.domain }}`
 
 or go to the dashboard at: https://epinio.{{ .Values.global.domain }}
+
+If you didn't specify a password the default one is `password`.
 
 For more information about Epinio, feel free to checkout https://epinio.io/ and https://docs.epinio.io/.

--- a/chart/epinio/templates/default-user.yaml
+++ b/chart/epinio/templates/default-user.yaml
@@ -22,6 +22,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 stringData:
   username: epinio
+  # bcrypt hash for 'password'
   password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace

--- a/chart/epinio/templates/default-user.yaml
+++ b/chart/epinio/templates/default-user.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 stringData:
   username: {{ .Values.api.username }}
-  password: {{ .Values.api.password }}
+  password: {{ .Values.api.passwordBcrypt }}
 ---
 apiVersion: v1
 kind: Secret

--- a/chart/epinio/templates/default-user.yaml
+++ b/chart/epinio/templates/default-user.yaml
@@ -22,6 +22,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 stringData:
   username: epinio
-  password: password
+  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
   namespaces: |
     workspace

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -61,7 +61,7 @@ api:
   # Default user username
   username: admin
   # Default user password (bcrypt hash for 'password')
-  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+  passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 
 # Minio subchart values
 minio:

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -60,7 +60,7 @@ s3:
 api:
   # Default user username
   username: admin
-  # Default user password
+  # Default user password (bcrypt hash for 'password')
   password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 
 # Minio subchart values

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -61,7 +61,7 @@ api:
   # Default user username
   username: admin
   # Default user password
-  password: password
+  password: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
 
 # Minio subchart values
 minio:


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1361
---

This PR will store the passwords as Bcrypt hashes instead of plaintext.