### PR TITLE
Ensure UI makes use of new theme setting

### DIFF
--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -45,6 +45,8 @@ spec:
           value: {{ .Values.epinioApiSkipSSL | quote }}
         - name: EPINIO_VERSION
           value: {{ .Values.epinioVersion | quote }}
+        - name: EPINIO_THEME
+          value: {{ .Values.epinioTheme | quote }}
         - name: HTTP_CLIENT_TIMEOUT_IN_SECS
           value: "120"
         - name: SESSION_STORE_SECRET

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -19,6 +19,8 @@ epinioWssUrl: ""
 epinioApiSkipSSL: "true"
 # This is the version that is displayed in the ui and should match that of the epinio it's targetting
 epinioVersion: "v0.8.0"
+# Epinio standalone only supports a single theme, either light or dark
+epinioTheme: "light"
 volumeMounts:
   - name: tmp
     mountPath: /tmp


### PR DESCRIPTION
- Epinio standalone only supports a single theme, either light or dark
- This exposes the setting and defaults to light mode
- https://github.com/epinio/ui/issues/125