### PR TITLE
Add more restrictions and proper group/fsgroup mappings to the server…

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -303,9 +303,13 @@ spec:
             httpGet:
               path: /ready
               port: 8030
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
+        runAsGroup: 3000
 
 ---
 apiVersion: v1


### PR DESCRIPTION
… pod

Adding runAsGroup because docs say:

"If this field is omitted, the primary group ID of the containers will be root(0)."

From here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

Not sure if this still applies when "runAsUser: 1000" and "runAsNonRoot: true"
are set.

Fixes [#1377](https://github.com/epinio/epinio/issues/1377)
Sibling PR: https://github.com/epinio/epinio/pull/1511/files