### PR TITLE
Epinio UI - Minor tidy up

### DIFF
--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -46,9 +46,9 @@ spec:
         - name: EPINIO_API_SKIP_SSL
           value: {{ .Values.epinioAPISkipSSL | quote }}
         - name: EPINIO_VERSION
-          value: {{ .Values.epinioVersion | quote }}
+          value: {{ (default .Chart.Version .Values.epinioVersion) | quote}}
         - name: EPINIO_THEME
-          value: {{ .Values.epinioTheme | quote }}
+          value: {{ (default "light" .Values.epinioTheme) | quote }}
         - name: HTTP_CLIENT_TIMEOUT_IN_SECS
           value: "120"
         - name: SESSION_STORE_SECRET

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -18,9 +18,9 @@ epinioWSSURL: ""
 # Domain that will serve the UI and be the origin of browser requests, used by CORS process
 epinioAllowedOrigins: ""
 # Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`
-epinioAPISkipSSL: "true"
+# epinioAPISkipSSL: "true"
 # This is the version that is displayed in the ui and should match that of the epinio it's targetting
-epinioVersion: "v0.8.0"
+# epinioVersion: "v0.8.0"
 # Epinio standalone only supports a single theme, either light or dark
 epinioTheme: "light"
 volumeMounts:

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -87,7 +87,8 @@ minio:
 
 epinio-ui:
   enabled: true
-  epinioVersion: "0.7.1"
+  epinioTheme: light
+  epinioVersion: "0.7.0"
   ingress:
     enabled: false
 


### PR DESCRIPTION
- Epinio Version
  - the ui version should show the epinio chart version (https://github.com/epinio/ui/issues/109)
  - the ui shows `Values.epinioVersion` and now falls back on `.Chart.Version`
  - `.Chart.Version` is the sub chart version (epinio-ui). Subcharts cannot currently read the parent chart version
  - still to do - either automate epinio ui chart version to match epinio chart version OR automatically update Values.epinioVersion when the epinio chart version is rev'ed
  - tested by
    - charts/chart (main) $ tar -cvzf epinio/charts/epinio-ui-0.3.2.tgz epinio-ui
    - charts/chart (main) $ helm template epinio epinio -f values.yaml
- Make the `epinioTheme` env var a little more obvious