### PR TITLE
fix: revert bash image used in staging steps.

### DIFF
--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -11,8 +11,8 @@ image:
     repository: epinio/epinio-server
     tag: ""
   bash:
-    repository: rancher/shell
-    tag: v0.1.16
+    repository: library/bash
+    tag: 5.1.4
   awscli:
     repository: amazon/aws-cli
     tag: 2.0.52


### PR DESCRIPTION
Ref https://github.com/epinio/epinio/issues/1541

rancher/shell uses user `shell:1000`, whereas `library/bash` uses `root:0`.
This is important for calls of `chown`.