### PR TITLE
Automate Epinio version update used by epinio-ui

### DIFF
--- a/updatecli/updatecli.d/epinio/epinio.yaml
+++ b/updatecli/updatecli.d/epinio/epinio.yaml
@@ -20,6 +20,7 @@ pullrequests:
     scmid: "helm-charts"
     targets:
       - "helm-charts"
+      - "epinioui"
     spec:
       labels:
         - "dependencies"
@@ -77,5 +78,15 @@ targets:
       name: "chart/epinio"
       file: "Chart.yaml"
       key: "appVersion"
-      versionincrement: minor
+      versionincrement: "minor"
 
+  epinioui:
+    name: "Update epinio version in chart epinio"
+    kind: "helmchart"
+    scmid: "helm-charts"
+    sourceid: "epinio"
+    spec:
+      name: "chart/epinio"
+      file: "values.yaml"
+      key: "epinio-ui.epinioVersion"
+      versionincrement: "minor"


### PR DESCRIPTION
This PR will automatically update the Epinio version used in the Helm chart "epinio" where the file is "values.yaml" and the key "epinio-ui.epinioVersion"
 
Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>