### PR TITLE
Explicitly set the settings file to a writable path

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -264,6 +264,8 @@ spec:
         - command: ["/epinio", "server"]
           args: ["--port", "8030"]
           env:
+            - name: EPINIO_SETTINGS
+              value: /tmp/settings.yaml
             - name: NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: ACCESS_CONTROL_ALLOW_ORIGIN


### PR DESCRIPTION
because it would panic otherwise.

Part of: https://github.com/epinio/epinio/pull/1586