### PR TITLE
1619 partly bump to release

### DIFF
--- a/chart/epinio/Chart.yaml
+++ b/chart/epinio/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: epinio
 sources:
 - https://github.com/epinio/epinio
-version: 1.0.0
+version: 1.0.1

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -98,10 +98,10 @@ containerregistry:
   image:
     registry:
       repository: registry
-      tag: 2.7.1
+      tag: 2.8.1
     nginx:
       repository: nginx
-      tag: 1.21.6
+      tag: 1.23.0
   imagePullPolicy: IfNotPresent
   # The ingressClassName is used to select the ingress controller. If
   # empty no class will be added to the ingresses.


### PR DESCRIPTION
Extracted the nginx and container registry fixes to a separate PR from here: https://github.com/epinio/helm-charts/pull/247

That's because we can easily bump these and fix the `F` in artifacthub. The others need upstream fixes and will take longer.