### PR TITLE
Additional label to support removal of dependency on `Deployment`

### DIFF
--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.19
+version: 0.1.20
 keywords:
 - epinio
 - paas

--- a/chart/application/templates/deployment.yaml
+++ b/chart/application/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         {{- include "epinio-application.labels" . | nindent 8 }}
         epinio.io/stage-id: {{ .Values.epinio.stageID | quote }}
+        epinio.io/app-container: {{ include "epinio-truncate" .Values.epinio.appName }}
     spec:
       serviceAccount: {{ .Release.Namespace }}
       serviceAccountName: {{ .Release.Namespace }}

--- a/chart/epinio/templates/default-app-chart.yaml
+++ b/chart/epinio/templates/default-app-chart.yaml
@@ -12,4 +12,4 @@ metadata:
 spec:
   shortDescription: Epinio standard deployment
   description: Epinio standard support chart for application deployment
-  helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.19/epinio-application-0.1.19.tgz
+  helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.20/epinio-application-0.1.20.tgz


### PR DESCRIPTION
Ref https://github.com/epinio/epinio/issues/1629

Added a pod label specifying the name of the main controller (`Deployment` in this standard chart), which is also the name of the app's container in the pod.

This labeling has to be performed by all custom charts for them to be working.
