### PR TITLE
Move `created-by` from label to annotation

### DIFF
--- a/chart/application/templates/_helpers.tpl
+++ b/chart/application/templates/_helpers.tpl
@@ -10,10 +10,16 @@ Common labels
 */}}
 {{- define "epinio-application.labels" -}}
 app.kubernetes.io/managed-by: epinio
-app.kubernetes.io/created-by: {{ .Values.epinio.username }}
 app.kubernetes.io/part-of: {{ .Release.Namespace }}
 helm.sh/chart: {{ include "epinio-application.chart" . }}
 {{ include "epinio-application.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Common annotations
+*/}}
+{{- define "epinio-application.annotations" -}}
+epinio.io/created-by: {{ .Values.epinio.username }}
 {{- end }}
 
 {{/*

--- a/chart/application/templates/deployment.yaml
+++ b/chart/application/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "epinio-application.labels" . | nindent 4 }}
+  annotations:
+    {{- include "epinio-application.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.epinio.replicaCount }}
   selector:
@@ -14,6 +16,7 @@ spec:
     metadata:
       annotations:
         app.kubernetes.io/name: {{ .Values.epinio.appName }}
+        {{- include "epinio-application.annotations" . | nindent 8 }}
         {{- with .Values.epinio.start }}
         epinio.io/start: {{ . | quote }}
         {{- end }}

--- a/chart/application/templates/ingress.yaml
+++ b/chart/application/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "epinio-application.labels" $ | nindent 4 }}
   annotations:
-    {{- include "epinio-application.annotations" . | nindent 4 }}
+    {{- include "epinio-application.annotations" $ | nindent 4 }}
 spec:
   secretName: {{ include "epinio-truncate" (print $.Values.epinio.appName "-" .id "-tls") }}
   dnsNames:
@@ -26,7 +26,7 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
-    {{- include "epinio-application.annotations" . | nindent 4 }}
+    {{- include "epinio-application.annotations" $ | nindent 4 }}
   labels:
     {{- include "epinio-application.labels" $ | nindent 4 }}
 spec:

--- a/chart/application/templates/ingress.yaml
+++ b/chart/application/templates/ingress.yaml
@@ -7,6 +7,8 @@ metadata:
   name: {{ include "epinio-truncate" (print $.Values.epinio.appName "-" .id) }}
   labels:
     {{- include "epinio-application.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "epinio-application.annotations" . | nindent 4 }}
 spec:
   secretName: {{ include "epinio-truncate" (print $.Values.epinio.appName "-" .id "-tls") }}
   dnsNames:
@@ -24,6 +26,7 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    {{- include "epinio-application.annotations" . | nindent 4 }}
   labels:
     {{- include "epinio-application.labels" $ | nindent 4 }}
 spec:

--- a/chart/application/templates/service.yaml
+++ b/chart/application/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    {{- include "epinio-application.annotations" . | nindent 4 }}
   labels:
     {{- include "epinio-application.labels" . | nindent 4 }}
   name: {{ include "epinio-truncate" .Values.epinio.appName }}

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -60,12 +60,6 @@ api:
       role: user
       workspaces:
         - workspace
-    - username: user1@epinio.io
-      passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
-      role: user
-      workspaces:
-        - workspace
-
 # Minio subchart values
 minio:
   enabled: true

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -60,6 +60,12 @@ api:
       role: user
       workspaces:
         - workspace
+    - username: user1@epinio.io
+      passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+      role: user
+      workspaces:
+        - workspace
+        
 # Minio subchart values
 minio:
   enabled: true

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -65,7 +65,7 @@ api:
       role: user
       workspaces:
         - workspace
-        
+
 # Minio subchart values
 minio:
   enabled: true


### PR DESCRIPTION
Moving the user from the `app.kubernetes.io/created-by` label to the `epinio.io/created-by` annotation to avoid the 63 char limitations.

It also adds a user with an email.