### PR TITLE
Use explicit pathType values for Ingress

### DIFF
--- a/chart/epinio/templates/ingress.yaml
+++ b/chart/epinio/templates/ingress.yaml
@@ -21,6 +21,27 @@ spec:
   - host: "epinio.{{ .Values.global.domain }}"
     http:
       paths:
+      - backend:
+          service:
+            name: epinio-server
+            port:
+              number: 80
+        path: /api
+        pathType: Prefix
+      - backend:
+          service:
+            name: epinio-server
+            port:
+              number: 80
+        path: /wapi
+        pathType: Prefix
+      - backend:
+          service:
+            name: epinio-server
+            port:
+              number: 80
+        path: /ready
+        pathType: Exact
   {{- if ".Values.epinio-ui.enabled" }}
       - backend:
           service:
@@ -28,29 +49,8 @@ spec:
             port:
               number: 80
         path: /
-        pathType: ImplementationSpecific
+        pathType: Prefix
   {{- end }}
-      - backend:
-          service:
-            name: epinio-server
-            port:
-              number: 80
-        path: /api
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: epinio-server
-            port:
-              number: 80
-        path: /wapi
-        pathType: ImplementationSpecific
-      - backend:
-          service:
-            name: epinio-server
-            port:
-              number: 80
-        path: /ready
-        pathType: ImplementationSpecific
   tls:
   - hosts:
     - "epinio.{{ .Values.global.domain }}"


### PR DESCRIPTION
to avoid unexpected implementations. Also move the "catch all" rule at
the end because in some cases it seems to matter (See:
https://github.com/epinio/epinio/issues/1663#issuecomment-1206834066)

Sibling PR: https://github.com/epinio/epinio/pull/1685