### PR TITLE
Introduce extraEnv for server deployment

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -288,6 +288,9 @@ spec:
             - name: INGRESS_CLASS_NAME
               value: "{{ .Values.ingress.ingressClassName }}"
             {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 -}}
+            {{- end }}
           image: "{{ default .Values.image.epinio.registry (include "registry-url" .) }}{{ .Values.image.epinio.repository }}:{{ default .Chart.AppVersion .Values.image.epinio.tag }}"
           livenessProbe:
             httpGet:

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -60,6 +60,10 @@ api:
       role: user
       workspaces:
         - workspace
+# Extra environment variables passed to the epinio-server pod.
+# extraEnv:
+# - name: MY_ENV_VAR
+#   value: "1.0"
 # Minio subchart values
 minio:
   enabled: true


### PR DESCRIPTION
This PR brings support for setting an extra environment variable(s) in epinio-server deployment, also more than one extraEnv variable/value can be set by using an indexes.

Usage:
```
 helm upgrade ... --set "extraEnv[0].name=SESSION_KEY" --set-string "extraEnv[0].value=12345"
```

This is first part addressing https://github.com/epinio/epinio/issues/1675

