### PR TITLE
 Trial a `bci-micro` derived image as replacement for `library/bash`.

### DIFF
--- a/chart/epinio/templates/stage-scripts.yaml
+++ b/chart/epinio/templates/stage-scripts.yaml
@@ -4,9 +4,9 @@ metadata:
   name: epinio-stage-scripts
   namespace: {{ .Release.Namespace }}
 data:
-  builderImage:  "{{ template "registry-url" . }}{{ .Values.image.builder.repository}}:{{ .Values.image.builder.tag }}"
-  downloadImage: "{{ template "registry-url" . }}{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
-  unpackImage:   "{{ template "registry-url" . }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
+  builderImage:  "{{ default .Values.image.builder.registry (include "registry-url" .) }}{{ .Values.image.builder.repository}}:{{ .Values.image.builder.tag }}"
+  downloadImage: "{{ default .Values.image.awscli.registry (include "registry-url" .) }}{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
+  unpackImage:   "{{ default .Values.image.bash.registry (include "registry-url" .) }}{{ .Values.image.bash.repository}}:{{ .Values.image.bash.tag }}"
   download: |-
     # Parameters
     # - PROTOCOL # s3 protocol

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -12,7 +12,7 @@ image:
   bash:
     registry: ghcr.io/
     repository: epinio/epinio-unpacker
-    tag: 1.0
+    tag: "1.0"
   awscli:
     repository: amazon/aws-cli
     tag: 2.0.52

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -10,8 +10,9 @@ image:
     repository: epinio/epinio-server
     tag: ""
   bash:
-    repository: library/bash
-    tag: 5.1.4
+    registry: ghcr.io/
+    repository: epinio/epinio-unpacker
+    tag: 1.0
   awscli:
     repository: amazon/aws-cli
     tag: 2.0.52


### PR DESCRIPTION
Ref: https://github.com/epinio/epinio/pull/1741

research: trial bci-micro derived image for staging
chore: extend the image refs for staging to allow arbitrary origin registries

Docker file:
```
FROM registry.suse.com/bci/bci-base AS stage
RUN zypper refresh && zypper --non-interactive  install -f tar gzip unzip bzip2 xz findutils

FROM registry.suse.com/bci/bci-micro
COPY --from=stage /bin/tar       /bin/tar
COPY --from=stage /usr/bin/unzip /usr/bin/unzip
COPY --from=stage /bin/gzip      /bin/gzip
COPY --from=stage /usr/bin/bzip2 /usr/bin/bzip2
COPY --from=stage /usr/bin/xz    /usr/bin/xz
COPY --from=stage /bin/find      /bin/find
```

Command: `docker build --tag epinio_unpack:latest --tag epinio_unpack:v1b --tag a99k/epinio_unpack:v1b .`
