### PR TITLE
Add Epinio UI Dex client

### DIFF
--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -43,6 +43,8 @@ spec:
           value: {{ default (printf "http://epinio-server.%s.svc.cluster.local" .Release.Namespace) .Values.epinioAPIURL }}
         - name: EPINIO_WSS_URL
           value: {{ default (printf "ws://epinio-server.%s.svc.cluster.local" .Release.Namespace) .Values.epinioWSSURL }}
+        - name: EPINIO_UI_URL
+          value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioUIURL }}
         - name: EPINIO_API_SKIP_SSL
           value: {{ .Values.epinioAPISkipSSL | quote }}
         - name: EPINIO_VERSION

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -53,6 +53,10 @@ spec:
           value: {{ (default .Chart.Version .Values.epinioVersion) | quote}}
         - name: EPINIO_THEME
           value: {{ (default "light" .Values.epinioTheme) | quote }}
+        - name: EPINIO_DEX_ENABLED
+          value: {{ (.Values.dex.enabled) }}
+        - name: EPINIO_DEX_SECRET
+          value: {{ (.Values.dex.ui.secret) | quote }}
         - name: HTTP_CLIENT_TIMEOUT_IN_SECS
           value: "120"
         - name: SESSION_STORE_SECRET

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -46,7 +46,7 @@ spec:
         - name: EPINIO_UI_URL
           value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioUIURL }}
         - name: EPINIO_API_SKIP_SSL
-          value: {{ .Values.epinioAPISkipSSL | quote }}
+          value: {{ (default "false" .Values.epinioAPISkipSSL) | quote }}
         - name: EPINIO_DEX_AUTH_URL
           value: {{ default (printf "https://auth.%s" .Values.global.domain) .Values.epinioDexURL }}
         - name: EPINIO_VERSION
@@ -54,9 +54,9 @@ spec:
         - name: EPINIO_THEME
           value: {{ (default "light" .Values.epinioTheme) | quote }}
         - name: EPINIO_DEX_ENABLED
-          value: {{ (.Values.dex.enabled) }}
+          value: {{ (default false .Values.dex.enabled) | quote }}
         - name: EPINIO_DEX_SECRET
-          value: {{ (.Values.dex.ui.secret) | quote }}
+          value: {{ (default "" .Values.dex.ui.secret) | quote }}
         - name: HTTP_CLIENT_TIMEOUT_IN_SECS
           value: "120"
         - name: SESSION_STORE_SECRET

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -52,8 +52,6 @@ spec:
           value: {{ (default "false" .Values.epinioUI.apiSkipSSL) | quote }}
         - name: EPINIO_DEX_AUTH_URL
           value: {{ default (printf "https://auth.%s" .Values.global.domain) .Values.epinioUI.dexURL }}
-        - name: EPINIO_VERSION
-          value: {{ (default .Chart.Version .Values.epinioUI.version) | quote}}
         - name: EPINIO_THEME
           value: {{ (default "light" .Values.epinioUI.theme) | quote }}
         - name: EPINIO_DEX_ENABLED

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -2,6 +2,9 @@
 {{- $encryptionKey := empty $secret | ternary (printf "%x" (randAscii 32)) (b64dec (default "" $secret.encryptionKey)) -}}
 {{- $sessionSecret := empty $secret | ternary (randAlphaNum 16) (b64dec (default "" $secret.sessionSecret)) -}}
 
+{{- $dexSecret := (lookup "v1" "Secret" .Release.Namespace "dex-config") -}}
+{{- $uiClientSecret := empty $dexSecret | ternary (.Values.dex.ui.secret) (b64dec (default "" $dexSecret.uiClientSecret)) -}}
+
 ---
 apiVersion: v1
 kind: Secret
@@ -54,9 +57,12 @@ spec:
         - name: EPINIO_THEME
           value: {{ (default "light" .Values.epinioUI.theme) | quote }}
         - name: EPINIO_DEX_ENABLED
-          value: {{ (default false .Values.dex.enabled) | quote }}
+          value: {{ (default false .Values.global.dex.enabled) | quote }}
         - name: EPINIO_DEX_SECRET
-          value: {{ (default "" .Values.dex.ui.secret) | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: dex-config
+              key: uiClientSecret
         - name: HTTP_CLIENT_TIMEOUT_IN_SECS
           value: "120"
         - name: SESSION_STORE_SECRET

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -48,7 +48,7 @@ spec:
         - name: EPINIO_API_SKIP_SSL
           value: {{ .Values.epinioAPISkipSSL | quote }}
         - name: EPINIO_DEX_AUTH_URL
-          value: {{ default (printf "http://%s.%s.svc.cluster.local:5556" .Values.dex.fullnameOverride .Release.Namespace) .Values.epinioDexURL }}
+          value: {{ default (printf "https://auth.%s" .Values.global.domain) .Values.epinioDexURL }}
         - name: EPINIO_VERSION
           value: {{ (default .Chart.Version .Values.epinioVersion) | quote}}
         - name: EPINIO_THEME

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -47,6 +47,8 @@ spec:
           value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioUIURL }}
         - name: EPINIO_API_SKIP_SSL
           value: {{ .Values.epinioAPISkipSSL | quote }}
+        - name: EPINIO_DEX_AUTH_URL
+          value: {{ default (printf "http://%s.%s.svc.cluster.local:5556" .Values.dex.fullnameOverride .Release.Namespace) .Values.epinioDexURL }}
         - name: EPINIO_VERSION
           value: {{ (default .Chart.Version .Values.epinioVersion) | quote}}
         - name: EPINIO_THEME

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -38,21 +38,21 @@ spec:
 
         env:
         - name: ALLOWED_ORIGINS
-          value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioAllowedOrigins }}
+          value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioUI.allowedOrigins }}
         - name: EPINIO_API_URL
-          value: {{ default (printf "http://epinio-server.%s.svc.cluster.local" .Release.Namespace) .Values.epinioAPIURL }}
+          value: {{ default (printf "http://epinio-server.%s.svc.cluster.local" .Release.Namespace) .Values.epinioUI.apiURL }}
         - name: EPINIO_WSS_URL
-          value: {{ default (printf "ws://epinio-server.%s.svc.cluster.local" .Release.Namespace) .Values.epinioWSSURL }}
+          value: {{ default (printf "ws://epinio-server.%s.svc.cluster.local" .Release.Namespace) .Values.epinioUI.wssURL }}
         - name: EPINIO_UI_URL
-          value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioUIURL }}
+          value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioUI.uiURL }}
         - name: EPINIO_API_SKIP_SSL
-          value: {{ (default "false" .Values.epinioAPISkipSSL) | quote }}
+          value: {{ (default "false" .Values.epinioUI.apiSkipSSL) | quote }}
         - name: EPINIO_DEX_AUTH_URL
-          value: {{ default (printf "https://auth.%s" .Values.global.domain) .Values.epinioDexURL }}
+          value: {{ default (printf "https://auth.%s" .Values.global.domain) .Values.epinioUI.dexURL }}
         - name: EPINIO_VERSION
-          value: {{ (default .Chart.Version .Values.epinioVersion) | quote}}
+          value: {{ (default .Chart.Version .Values.epinioUI.version) | quote}}
         - name: EPINIO_THEME
-          value: {{ (default "light" .Values.epinioTheme) | quote }}
+          value: {{ (default "light" .Values.epinioUI.theme) | quote }}
         - name: EPINIO_DEX_ENABLED
           value: {{ (default false .Values.dex.enabled) | quote }}
         - name: EPINIO_DEX_SECRET
@@ -83,7 +83,7 @@ spec:
         - name: CONSOLE_PROXY_TLS_ADDRESS
           value: 0.0.0.0:8000
         - name: LOG_LEVEL
-          value: {{ .Values.logLevel | quote }}
+          value: {{ .Values.epinioUI.logLevel | quote }}
 
         {{- with .Values.volumeMounts }}
         volumeMounts:

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -15,6 +15,7 @@ logLevel: info
 # API URL of epinio instance, for proxied connections, defaults to http://epinio-server.%s.svc.cluster.local"
 epinioAPIURL: ""
 epinioWSSURL: ""
+epinioUIURL: ""
 # Domain that will serve the UI and be the origin of browser requests, used by CORS process
 epinioAllowedOrigins: ""
 # Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -24,9 +24,13 @@ ingress:
 global:
   domain: ui.epinio.dev
   tlsIssuer: selfsigned-issuer
+  dex:
+    enabled: true
 dex:
   ui:
-    secret: "dev-secret"
+    # secret should be supplied by dex automatically, this is just a fall back
+    secret: ""
+    # Defaults to https://epinio.{{ .Values.global.domain }}/auth/verify/
     redirectURI: ""
 volumeMounts:
   - name: tmp

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -12,7 +12,9 @@ global:
   domain: ui.epinio.dev
   tlsIssuer: selfsigned-issuer
 dex:
-  fullnameOverride: dex
+  ui:
+    secret: ""
+    redirectURI: ""
 logLevel: info
 # API URL of epinio instance, for proxied connections, defaults to http://epinio-server.%s.svc.cluster.local"
 epinioAPIURL: ""

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -11,11 +11,14 @@ ingress:
 global:
   domain: ui.epinio.dev
   tlsIssuer: selfsigned-issuer
+dex:
+  fullnameOverride: dex
 logLevel: info
 # API URL of epinio instance, for proxied connections, defaults to http://epinio-server.%s.svc.cluster.local"
 epinioAPIURL: ""
 epinioWSSURL: ""
 epinioUIURL: ""
+epinioDexURL: ""
 # Domain that will serve the UI and be the origin of browser requests, used by CORS process
 epinioAllowedOrigins: ""
 # Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`

--- a/chart/epinio-ui/values.yaml
+++ b/chart/epinio-ui/values.yaml
@@ -4,6 +4,19 @@ epinioUI:
     repository: epinio/epinio-ui
     tag: v1.5.1-0.0.3
   imagePullPolicy: IfNotPresent
+  uiURL: ""
+  # Epinio standalone only supports a single theme, either light or dark
+  theme: "light"
+  # API URL of epinio instance, for proxied connections, defaults to http://epinio-server.%s.svc.cluster.local"
+  apiURL: ""
+  wssURL: ""
+  dexURL: ""
+  # Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`
+  apiSkipSSL: "true"
+  # version: ""
+  logLevel: info
+  # Domain that will serve the UI and be the origin of browser requests, used by CORS process
+  allowedOrigins: ""
 ingress:
   enabled: true
   # The ingressClassName is used to select the ingress controller. If empty no class will be added to the ingresses.
@@ -13,22 +26,8 @@ global:
   tlsIssuer: selfsigned-issuer
 dex:
   ui:
-    secret: ""
+    secret: "dev-secret"
     redirectURI: ""
-logLevel: info
-# API URL of epinio instance, for proxied connections, defaults to http://epinio-server.%s.svc.cluster.local"
-epinioAPIURL: ""
-epinioWSSURL: ""
-epinioUIURL: ""
-epinioDexURL: ""
-# Domain that will serve the UI and be the origin of browser requests, used by CORS process
-epinioAllowedOrigins: ""
-# Skip checking for valid SSL cert when making requests to `EPINIO_API_URL`
-# epinioAPISkipSSL: "true"
-# This is the version that is displayed in the ui and should match that of the epinio it's targetting
-# epinioVersion: "v0.8.0"
-# Epinio standalone only supports a single theme, either light or dark
-epinioTheme: "light"
 volumeMounts:
   - name: tmp
     mountPath: /tmp

--- a/chart/epinio/Chart.lock
+++ b/chart/epinio/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: epinio-ui
   repository: https://epinio.github.io/helm-charts
   version: 1.5.3
-digest: sha256:edaf7fec6b9567423ca0175493c21a542afe293e3a48d853acf9eb0b3d36024a
-generated: "2023-01-12T09:59:16.775081808+01:00"
+digest: sha256:f406f3218f85f6c1c11f39a264e653e38c1835487979a76bcd8b57d61260c1f9
+generated: "2023-01-26T10:30:59.819318562Z"

--- a/chart/epinio/Chart.yaml
+++ b/chart/epinio/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
 apiVersion: v2
 appVersion: v1.6.2
 dependencies:
-- condition: dex.enabled, global.dex.enabled
+- condition: global.dex.enabled
   name: dex
   repository: https://charts.dexidp.io
   tags:

--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -36,10 +36,18 @@ stringData:
       # https://dexidp.io/docs/custom-scopes-claims-clients/#cross-client-trust-and-authorized-party
       trustedPeers:
       - epinio-cli
+      - epinio-ui
 
     - id: epinio-cli
       name: 'Epinio cli'
       public: true
+
+    - id: epinio-ui
+      name: 'Epinio UI'
+      secret: 'jetstream-dex-epinio-ui'
+      # Shouldn't be public, https://dexidp.io/docs/custom-scopes-claims-clients/#public-clients
+      redirectURIs:
+      - {{ .Values.dex.ui.redirectURI | default (printf "https://epinio.%s/verify-auth" .Values.global.domain) | quote }}
 
 ---
 apiVersion: v1

--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -47,7 +47,7 @@ stringData:
       secret: 'jetstream-dex-epinio-ui'
       # Shouldn't be public, https://dexidp.io/docs/custom-scopes-claims-clients/#public-clients
       redirectURIs:
-      - {{ .Values.dex.ui.redirectURI | default (printf "https://epinio.%s/verify-auth" .Values.global.domain) | quote }}
+      - {{ .Values.dex.ui.redirectURI | default (printf "https://epinio.%s/auth/verify" .Values.global.domain) | quote }}
 
 ---
 apiVersion: v1

--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.dex.enabled -}}
+{{- if .Values.global.dex.enabled -}}
+
+{{- $dexSecret := (lookup "v1" "Secret" .Release.Namespace "dex-config").data -}}
+{{- $uiClientSecret := empty $dexSecret | ternary (randAlphaNum 16) (b64dec (default "" $dexSecret.uiClientSecret)) -}}
 
 ---
 apiVersion: v1
@@ -11,6 +14,7 @@ metadata:
 stringData:
   issuer: "https://auth.{{ .Values.global.domain }}"
   endpoint: {{ printf "http://%s.%s.svc.cluster.local:5556" .Values.dex.fullnameOverride .Release.Namespace }}
+  uiClientSecret: {{ $uiClientSecret }}
   config.yaml: |-
     issuer: "https://auth.{{ .Values.global.domain }}"
     storage:
@@ -44,7 +48,7 @@ stringData:
 
     - id: epinio-ui
       name: 'Epinio UI'
-      secret: {{ .Values.dex.ui.secret | quote }}
+      secret: {{ $uiClientSecret | quote }}
       # Shouldn't be public, https://dexidp.io/docs/custom-scopes-claims-clients/#public-clients
       redirectURIs:
       - {{ .Values.dex.ui.redirectURI | default (printf "https://epinio.%s/auth/verify/" .Values.global.domain) | quote }}

--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -44,10 +44,10 @@ stringData:
 
     - id: epinio-ui
       name: 'Epinio UI'
-      secret: 'jetstream-dex-epinio-ui'
+      secret: {{ .Values.dex.ui.secret | quote }}
       # Shouldn't be public, https://dexidp.io/docs/custom-scopes-claims-clients/#public-clients
       redirectURIs:
-      - {{ .Values.dex.ui.redirectURI | default (printf "https://epinio.%s/auth/verify" .Values.global.domain) | quote }}
+      - {{ .Values.dex.ui.redirectURI | default (printf "https://epinio.%s/auth/verify/" .Values.global.domain) | quote }}
 
 ---
 apiVersion: v1

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -263,7 +263,7 @@ spec:
       - name: image-export-volume
         persistentVolumeClaim:
           claimName: image-export-pvc
-{{- if .Values.dex.enabled }}
+{{- if .Values.global.dex.enabled }}
       - name: dex-tls
         secret:
           secretName: dex-tls
@@ -327,7 +327,7 @@ spec:
             mountPath: /tmp
           - name: image-export-volume
             mountPath: /image-export
-{{- if .Values.dex.enabled }}
+{{- if .Values.global.dex.enabled }}
           - name: dex-tls
             mountPath: /etc/ssl/certs/dex-tls.pem
             subPath: tls.crt

--- a/chart/epinio/values.schema.json
+++ b/chart/epinio/values.schema.json
@@ -274,7 +274,6 @@
         }
       },
       "required": [
-        "enabled",
         "configSecret",
         "fullnameOverride"
       ]

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -117,8 +117,6 @@ epinio-ui:
   epinioUI:
     theme: light
     version: "v1.6.1"
-  dex:
-    enabled: true
   ingress:
     enabled: false
 

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -82,7 +82,7 @@ dex:
     create: false
     name: "dex-config"
   ui:
-    secret: ""
+    secret: "dev-secret"
     # Defaults to https://epinio.{{ .Values.global.domain }}/auth/verify/
     redirectURI: ""
 

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -75,14 +75,14 @@ api:
 
 # Dex subchart values -- None for now, and sub chart disabled
 dex:
-  enabled: true
   # hardcode this, to avoid problems with release name
   fullnameOverride: "dex"
   configSecret:
     create: false
     name: "dex-config"
   ui:
-    secret: "dev-secret"
+    # secret should be supplied by dex automatically, this is just a fall back
+    secret: ""
     # Defaults to https://epinio.{{ .Values.global.domain }}/auth/verify/
     redirectURI: ""
 
@@ -119,8 +119,6 @@ epinio-ui:
     version: "v1.6.1"
   dex:
     enabled: true
-    ui:
-      secret: "dev-secret"
   ingress:
     enabled: false
 
@@ -148,6 +146,8 @@ serviceCatalog:
   enableDevServices: true
 
 global:
+  dex:
+    enabled: true
   # The domain that will be used to access the epinio API server and the registry
   domain: ""
   # Connection details for the container registry.

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -81,6 +81,9 @@ dex:
   configSecret:
     create: false
     name: "dex-config"
+  ui:
+    # Defaults to https://epinio.{{ .Values.global.domain }}/verify-auth
+    redirectURI: ""
 
 # Extra environment variables passed to the epinio-server pod.
 # extraEnv:

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -116,7 +116,6 @@ epinio-ui:
   enabled: true
   epinioUI:
     theme: light
-    version: "v1.6.1"
   ingress:
     enabled: false
 

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -82,7 +82,8 @@ dex:
     create: false
     name: "dex-config"
   ui:
-    # Defaults to https://epinio.{{ .Values.global.domain }}/verify-auth
+    secret: ""
+    # Defaults to https://epinio.{{ .Values.global.domain }}/auth/verify/
     redirectURI: ""
 
 # Extra environment variables passed to the epinio-server pod.

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -114,8 +114,13 @@ minio:
 
 epinio-ui:
   enabled: true
-  epinioTheme: light
-  epinioVersion: "v1.6.2"
+  epinioUI:
+    theme: light
+    version: "v1.6.1"
+  dex:
+    enabled: true
+    ui:
+      secret: "dev-secret"
   ingress:
     enabled: false
 

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -78,13 +78,3 @@ targets:
       file: "Chart.yaml"
       key: "appVersion"
       versionincrement: "minor"
-
-  epinioui:
-    name: "Update epinio version in chart epinio"
-    kind: "helmchart"
-    scmid: "helm-charts"
-    spec:
-      name: "chart/epinio"
-      file: "values.yaml"
-      key: "epinio-ui.epinioVersion"
-      versionincrement: "minor"


### PR DESCRIPTION
- Contributes to https://github.com/epinio/ui/issues/167
- Related PRs https://github.com/rancher/dashboard/pull/7299, https://github.com/epinio/ui-backend/pull/9
- This moves the flag to enable dex out from `dex.enabled` to `global.dex.enabled` as the epinio-ui subchart uses it
- Also refactored epinio-ui chart values to make it clearer which are used directly in the app itself