### PR TITLE
Added PVC for image export

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -283,6 +283,8 @@ spec:
               value: "{{ .Values.global.tlsIssuer }}"
             - name: TRACE_LEVEL
               value: "{{ .Values.server.traceLevel }}"
+            - name: APP_IMAGE_EXPORTER
+              value: "{{ default .Values.image.skopeo.registry (include "registry-url" .) }}{{ .Values.image.skopeo.repository}}:{{ .Values.image.skopeo.tag }}"
             {{- if or .Values.s3.certificateSecret .Values.minio.enabled }}
             - name: S3_CERTIFICATE_SECRET
               value: {{ default "minio-tls" .Values.s3.certificateSecret }}

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -283,8 +283,11 @@ spec:
               value: "{{ .Values.global.tlsIssuer }}"
             - name: TRACE_LEVEL
               value: "{{ .Values.server.traceLevel }}"
+            {{- $imageSkopeo := .Values.image.skopeo -}}
+            {{- if $imageSkopeo }}
             - name: APP_IMAGE_EXPORTER
-              value: "{{ default .Values.image.skopeo.registry (include "registry-url" .) }}{{ .Values.image.skopeo.repository}}:{{ .Values.image.skopeo.tag }}"
+              value: "{{ default $imageSkopeo.registry (include "registry-url" .) }}{{ $imageSkopeo.repository}}:{{ $imageSkopeo.tag }}"
+            {{- end }}
             {{- if or .Values.s3.certificateSecret .Values.minio.enabled }}
             - name: S3_CERTIFICATE_SECRET
               value: {{ default "minio-tls" .Values.s3.certificateSecret }}

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -260,6 +260,9 @@ spec:
       volumes:
       - name: tmp-volume
         emptyDir: {}
+      - name: image-export-volume
+        persistentVolumeClaim:
+          claimName: image-export-pvc
       - name: dex-tls
         secret:
           secretName: dex-tls
@@ -306,6 +309,8 @@ spec:
           volumeMounts:
           - name: tmp-volume
             mountPath: /tmp
+          - name: image-export-volume
+            mountPath: /image-export
           - name: dex-tls
             mountPath: /etc/ssl/certs/dex-tls.pem
             subPath: tls.crt
@@ -321,6 +326,18 @@ spec:
         runAsUser: 1000
         runAsGroup: 3000
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: image-export-pvc
+  namespace: epinio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
 ---
 apiVersion: v1
 kind: Service

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -16,6 +16,10 @@ image:
   awscli:
     repository: amazon/aws-cli
     tag: 2.8.5
+  skopeo:
+    registry: quay.io/
+    repository: skopeo/stable
+    tag: v1.10
   kubectl:
     repository: rancher/kubectl
     tag: v1.22.6


### PR DESCRIPTION
Ref:
- https://github.com/epinio/epinio/issues/1352
---

This PR adds a PVC to the Epinio server and mounts the volume used to cache the container image to be exported.