### PR TITLE
chore: bump aws cli to 2.8.9

### DIFF
--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -15,7 +15,7 @@ image:
     tag: "1.0"
   awscli:
     repository: amazon/aws-cli
-    tag: 2.8.5
+    tag: 2.8.9
   skopeo:
     registry: quay.io/
     repository: skopeo/stable


### PR DESCRIPTION
Ref https://github.com/rancherlabs/image-scanning/issues/1590