### PR TITLE
Update service-catalog helmchart to latest bitnami

### DIFF
--- a/chart/epinio/templates/service-catalog.yaml
+++ b/chart/epinio/templates/service-catalog.yaml
@@ -15,9 +15,9 @@ spec:
     This database is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
   chart: postgresql
-  chartVersion: 11.1.28
+  chartVersion: 12.1.6
   serviceIcon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-220x234.png
-  appVersion: 14.2.0
+  appVersion: 15.1.0
   helmRepo:
     name: bitnami
     url: "https://charts.bitnami.com/bitnami"
@@ -38,9 +38,9 @@ spec:
     This database is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
   chart: mysql
-  chartVersion: 8.9.6
+  chartVersion: 9.4.5
   serviceIcon: https://bitnami.com/assets/stacks/mysql/img/mysql-stack-220x234.png
-  appVersion: 8.0.29
+  appVersion: 8.0.31
   helmRepo:
     name: bitnami
     url: "https://charts.bitnami.com/bitnami"
@@ -61,9 +61,9 @@ spec:
     This database is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
   chart: redis
-  chartVersion: 16.9.2
+  chartVersion: 17.3.17
   serviceIcon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
-  appVersion: 6.2.7
+  appVersion: 7.0.7
   helmRepo:
     name: bitnami
     url: "https://charts.bitnami.com/bitnami"
@@ -84,9 +84,9 @@ spec:
     This instance is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
   chart: rabbitmq
-  chartVersion: 9.0.5
+  chartVersion: 11.2.2
   serviceIcon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
-  appVersion: 3.9.17
+  appVersion: 3.11.5
   helmRepo:
     name: bitnami
     url: https://charts.bitnami.com/bitnami
@@ -107,9 +107,9 @@ spec:
     This instance is running inside the cluster so it's probably not a good choice for production
     environments, at least with this default configuration.
   chart: mongodb
-  chartVersion: 13.1.0
+  chartVersion: 13.6.2
   serviceIcon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
-  appVersion: 6.0.1
+  appVersion: 6.0.3
   helmRepo:
     name: bitnami
     url: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Referring to bug: https://github.com/epinio/epinio/issues/1969

Updating the service-catalog so that we can now use the latest bitnami helmcharts

https://artifacthub.io/packages/helm/bitnami/mongodb
https://artifacthub.io/packages/helm/bitnami/mysql
https://artifacthub.io/packages/helm/bitnami/postgresql
https://artifacthub.io/packages/helm/bitnami/rabbitmq
https://artifacthub.io/packages/helm/bitnami/redis

cc: @andreas-kupries