### PR TITLE
Custom annotations also for dex's ingress

### DIFF
--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -79,6 +79,9 @@ metadata:
     cert-manager.io/cluster-issuer: {{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer | quote }}
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
   ingressClassName: "{{ .Values.ingress.ingressClassName }}"


### PR DESCRIPTION
Ref. https://github.com/epinio/epinio/issues/1970

I copied the code block used for the server's ingress also to dex template so now both services should be able to use the same annotations.

More annotation entries could be set for eg. by:
```
--set 'ingress.annotations.traefik\.kubernetes\.io/router\.entrypoint=websecure' --set 'ingress.annotations.traefik\.ingress\.kubernetes\.io/router\.tls=true'
```