### PR TITLE
Fix for latest Epinio version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
-      - name: Checkout
+
+      - name: Checkout Epinio
         uses: actions/checkout@v3
         with:
           repository: 'epinio/epinio'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout Epinio
-        uses: actions/checkout@v3
-        with:
-          repository: 'epinio/epinio'
-          path: epinio
-          fetch-depth: 0
-
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'epinio/epinio'
+          path: epinio
+          fetch-depth: 0
 
       - name: Configure Git
         run: |

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Checkout Epinio
+        uses: actions/checkout@v3
+        with:
+          repository: 'epinio/epinio'
+          path: epinio
+          fetch-depth: 0
+
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@v2
 

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -12,6 +12,12 @@ scms:
       token: '{{ requiredEnv .github.epinio.token }}'
       username: "{{ .github.epinio.username }}"
       branch: "{{ .github.epinio.branch }}"
+  
+  epinio:
+    kind: "git"
+    spec:
+      url: "git@github.com:epinio/epinio.git"
+      branch: "main"
 
 # Define pullrequest configuration if one needs to be created
 pullrequests:
@@ -27,12 +33,10 @@ pullrequests:
 sources:
   epinio:
     name: "Get Latest epinio version"
-    kind: "githubrelease"
+    kind: "gittag"
+    scmid: "epinio"
     spec:
-      owner: "epinio"
-      repository: "epinio"
-      username: '{{ requiredEnv .github.epinio.username }}'
-      token: '{{ requiredEnv .github.epinio.token }}'
+      path: "./epinio/"
 
 # Defines condition that must pass in order to update targets
 conditions:

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -12,12 +12,6 @@ scms:
       token: '{{ requiredEnv .github.epinio.token }}'
       username: "{{ .github.epinio.username }}"
       branch: "{{ .github.epinio.branch }}"
-  
-  epinio:
-    kind: "git"
-    spec:
-      url: "git@github.com:epinio/epinio.git"
-      branch: "main"
 
 # Define pullrequest configuration if one needs to be created
 pullrequests:
@@ -34,9 +28,10 @@ sources:
   epinio:
     name: "Get Latest epinio version"
     kind: "gittag"
-    scmid: "epinio"
     spec:
       path: "./epinio/"
+      versionfilter:
+        kind: semver
 
 # Defines condition that must pass in order to update targets
 conditions:


### PR DESCRIPTION
Fix #334

We need to fetch the latest Epinio version from the tag instead of the release

EDIT:

```
✔ Bump epinio server version:
	Source:
		✔ [epinio] Get Latest epinio version (kind: gittag)
	Condition:
		✔ [dockerImage] Check that ghcr.io/epinio/epinio-server:v1.6.1 is published (kind: dockerimage)
		✔ [dockerImageRegistry] Check that 'ghcr.io' registry is used in Helm chart epinio (kind: yaml)
		✔ [dockerImageRepository] Check that container image repository 'epinio/epinio-server' is used in Helm chart epinio (kind: yaml)
	Target:
		✔ [epinioui] Update epinio version in chart epinio (kind: helmchart)
		✔ [helm-charts] Update epinio version in chart epinio (kind: helmchart)
```

https://github.com/epinio/helm-charts/actions/runs/4102641541/jobs/7075852794
