### PR TITLE
Remove the dex cert fighting with the ingress derived dex-tls cert over the dex-tls secret

### DIFF
--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -40,7 +40,6 @@ stringData:
     - id: epinio-cli
       name: 'Epinio cli'
       public: true
-      
 
 ---
 apiVersion: v1
@@ -54,20 +53,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 stringData:
   username: "admin@epinio.io"
-
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: dex
-  namespace: "{{ .Release.Namespace }}"
-spec:
-  dnsNames:
-  - "auth.{{ .Values.global.domain }}"
-  issuerRef:
-    kind: ClusterIssuer
-    name: {{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer | quote }}
-  secretName: dex-tls
 
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Ref https://github.com/epinio/epinio/issues/2041

Candidate fix A: Remove the superfluous manually specified cert.
