### PR TITLE
Drop cluster issuer annotation from ingress

### DIFF
--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -76,7 +76,6 @@ metadata:
   name: dex
   namespace: {{ .Release.Namespace }}
   annotations:
-    cert-manager.io/cluster-issuer: {{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer | quote }}
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- range $key, $value := .Values.ingress.annotations }}


### PR DESCRIPTION
Ref: https://github.com/epinio/epinio/issues/2041

Fix candidate B: Remove trigger for auto-generated cert
