### PR TITLE
Fixed some `updatecli` deprecated fields and removed unused source

### DIFF
--- a/updatecli/updatecli.d/autodiscovery.yaml
+++ b/updatecli/updatecli.d/autodiscovery.yaml
@@ -4,7 +4,7 @@ name: "Autodiscovery"
 autodiscovery:
   groupby: individual
   scmid: default
-  pullrequestid: default
+  actionid: default
   crawlers:
     helm:
 
@@ -20,9 +20,9 @@ scms:
       username: "{{ .github.epinio.username }}"
       branch: "{{ .github.epinio.branch }}"
 
-pullrequests:
+actions:
   default:
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "default"
     spec:
       automerge: true

--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -1,5 +1,6 @@
 ---
-title: "Bump epinio ui version"
+name: "Bump epinio ui version"
+
 # Define git repository configuration to know where to push changes
 scms:
   helm-charts:
@@ -29,21 +30,10 @@ sources:
       versionfilter:
         kind: semver
 
-  epinio:
-    name: "Get Latest epinio version"
-    kind: "githubrelease"
-    spec:
-      owner: "epinio"
-      repository: "epinio"
-      username: '{{ requiredEnv .github.epinio.username }}'
-      token: '{{ requiredEnv .github.epinio.token }}'
-
-
 conditions:
   dockerImage:
     name: 'Check that ghcr.io/epinio/epinio-ui:{{ source "ui-backend-tag" }} exists'
     kind: "dockerimage"
-    sourceid: "ui-backend-tag"
     spec:
       image: "ghcr.io/epinio/epinio-ui"
       architecture: "amd64"
@@ -53,7 +43,6 @@ targets:
     name: "Update Epinio UI backend image for Helm Chart chart/epinio-ui"
     kind: "helmchart"
     scmid: "helm-charts"
-    sourceid: "ui-backend-tag"
     transformers:
       - addprefix: "ghcr.io/epinio/epinio-ui:"
     spec:
@@ -65,9 +54,9 @@ targets:
       appversion: true
 
 # Define pullrequest configuration if one needs to be created
-pullrequests:
+actions:
   helm-charts:
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "helm-charts"
     spec:
       automerge: true

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -1,5 +1,6 @@
 ---
 name: "Bump epinio server version"
+
 # Define git repository configuration to know where to push changes
 scms:
   helm-charts:
@@ -14,9 +15,9 @@ scms:
       branch: "{{ .github.epinio.branch }}"
 
 # Define pullrequest configuration if one needs to be created
-pullrequests:
+actions:
   helm-charts:
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "helm-charts"
     spec:
       labels:
@@ -38,7 +39,6 @@ conditions:
   dockerImage:
     name: 'Check that ghcr.io/epinio/epinio-server:{{ source "epinio" }} is published'
     kind: "dockerimage"
-    sourceid: "epinio"
     spec:
       image: "ghcr.io/epinio/epinio-server"
       architecture: "amd64"
@@ -69,7 +69,6 @@ targets:
     name: "Update epinio version in chart epinio"
     kind: "helmchart"
     scmid: "helm-charts"
-    sourceid: "epinio"
     spec:
       name: "chart/epinio"
       file: "Chart.yaml"
@@ -80,7 +79,6 @@ targets:
     name: "Update epinio version in chart epinio"
     kind: "helmchart"
     scmid: "helm-charts"
-    sourceid: "epinio"
     spec:
       name: "chart/epinio"
       file: "values.yaml"


### PR DESCRIPTION
`updatecli` was warning us about some deprecated fields.

It also removes an unused `source` and fixes the title/name of the pipeline.

Fixed as suggested.

```
WARNING: The `pullrequests` keyword is deprecated in favor of `actions`, please update this manifest. Updatecli will continue the execution while trying to translate `pullrequests` to `actions`.
WARNING: The kind "github" for actions is deprecated in favor of 'github/pullrequest'
Loading Pipeline "updatecli/updatecli.d/epinio-ui.yaml"
WARNING: The `autodiscovery.pullrequestid` keyword is deprecated in favor of `autodiscovery.actionid`, please update this manifest. Updatecli will continue the execution while trying to translate `autodiscovery.pullrequestid` to `autodiscovery.actionid`.
```

