### PR TITLE
Fixed epinio-ui version update

### DIFF
--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -28,7 +28,7 @@ sources:
     scmid: ui-backend
     spec:
       versionfilter:
-        kind: semver
+        kind: latest
 
 conditions:
   dockerImage:


### PR DESCRIPTION
Since the `ui-backend` is not using semantic versioning we need to use the `latest` tag.