### PR TITLE
Fixed chart testing (upgrade)

### DIFF
--- a/chart/upgrade-responder/Chart.lock
+++ b/chart/upgrade-responder/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://grafana.github.io/helm-charts
   version: 6.50.7
 digest: sha256:e6c72e24bc0c7203aad45dab3a597272cd85f0f2c65703b479e9c2deda258734
-generated: "2023-02-14T14:28:53.752568578Z"
+generated: "2023-02-17T11:33:33.910611152+01:00"

--- a/chart/upgrade-responder/requirements.lock
+++ b/chart/upgrade-responder/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: influxdb
-  repository: https://helm.influxdata.com
-  version: 4.12.0
-- name: grafana
-  repository: https://grafana.github.io/helm-charts
-  version: 6.45.1
-digest: sha256:27149aa4d24d75752023d0a8ce8b748b7fad5d02b69dfcbb34722affc6001a5f
-generated: "2022-12-06T15:09:21.235382569+01:00"


### PR DESCRIPTION
Fixed for outdated (and not required) requirements.lock: https://github.com/epinio/helm-charts/actions/runs/4202786313/jobs/7291383855

```
Error: Error installing charts: Error building dependencies for chart 'upgrade-responder => (version: "0.1.5", path: "chart/upgrade-responder")': Error waiting for process: exit status 1
Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml). Please update the dependencies
```
