### PR TITLE
fix: create nicer-named replacement for `email` template variable

### DIFF
--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -1,7 +1,7 @@
 questions:
-- variable: email
-  label: Email
-  description: "Email to use for getting notifications about your certificates"
+- variable: global.tlsIssuerMail
+  label: Issuer Email Receiver
+  description: "Email address to receive the certificate notification emails send by the `letsencrypt-production` issuer"
   type: string
   required: false
   group: "General settings"

--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -1,5 +1,5 @@
 questions:
-- variable: global.tlsIssuerMail
+- variable: global.tlsIssuerEmail
   label: Issuer Email Receiver
   description: "Email address to receive the certificate notification emails send by the `letsencrypt-production` issuer"
   type: string

--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -15,7 +15,7 @@ metadata:
   name: letsencrypt-production
 spec:
   acme:
-    email: {{ .Values.email }}
+    email: {{ .Values.global.tlsIssuerMail | default .Values.email | quote }}
     preferredChain: ""
     privateKeySecretRef:
       name: letsencrypt-production

--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -15,7 +15,7 @@ metadata:
   name: letsencrypt-production
 spec:
   acme:
-    email: {{ .Values.global.tlsIssuerMail | default .Values.email | quote }}
+    email: {{ .Values.global.tlsIssuerEmail | default .Values.email | quote }}
     preferredChain: ""
     privateKeySecretRef:
       name: letsencrypt-production

--- a/chart/epinio/values.schema.json
+++ b/chart/epinio/values.schema.json
@@ -180,6 +180,9 @@
         "tlsIssuer": {
           "type": "string"
         },
+        "tlsIssuerMail": {
+          "type": "string"
+        },
         "registryURL": {
           "type": "string"
         },

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -2,7 +2,12 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-# The email address you are planning to use for getting notifications about your certificates.
+# Fall back email address to receive notifications from the `letsencrypt-production` issuer.
+#
+# __SUPERCEDED__ by `global.tlsIssuerMail`.
+#
+# Kept for backward compatibility, here and in the templates.
+
 email: "epinio@suse.com"
 
 image:
@@ -174,5 +179,7 @@ global:
   # The URL of the container registry from where to pull container images for the various
   # created Pods. Don't confuse this registry with the "Epinio registry" which is the one
   # where Epinio stores the application images.
+  tlsIssuerMail: "epinio@suse.com"
+  # Email address to receive the certificate notification emails send by the `letsencrypt-production` issuer.
   cattle:
     systemDefaultRegistry: ""

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -176,10 +176,10 @@ global:
   # The name of the cluster issuer to use.
   # Epinio creates three options: 'epinio-ca', 'letsencrypt-production', and 'selfsigned-issuer'.
   tlsIssuer: "epinio-ca"
+  # Email address to receive the certificate notification emails send by the `letsencrypt-production` issuer.
+  tlsIssuerEmail: "epinio@suse.com"
   # The URL of the container registry from where to pull container images for the various
   # created Pods. Don't confuse this registry with the "Epinio registry" which is the one
   # where Epinio stores the application images.
-  tlsIssuerMail: "epinio@suse.com"
-  # Email address to receive the certificate notification emails send by the `letsencrypt-production` issuer.
   cattle:
     systemDefaultRegistry: ""


### PR DESCRIPTION
fix #348 

Note: for backward compat keeping `email` as fallback

Epinio PR ref https://github.com/epinio/epinio/pull/2088
Documentation ref https://github.com/epinio/docs/pull/214

