### PR TITLE
Fixed check for uiClientSecret value

### DIFF
--- a/chart/epinio/templates/dex.yaml
+++ b/chart/epinio/templates/dex.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.global.dex.enabled -}}
 
-{{- $dexSecret := (lookup "v1" "Secret" .Release.Namespace "dex-config").data -}}
-{{- $uiClientSecret := empty $dexSecret | ternary (randAlphaNum 16) (b64dec (default "" $dexSecret.uiClientSecret)) -}}
+{{- $dexSecret := (lookup "v1" "Secret" .Release.Namespace "dex-config").data | default dict -}}
+{{- $prevUiClientSecret := (get $dexSecret "uiClientSecret") -}}
+{{- $uiClientSecret := empty $prevUiClientSecret | ternary (randAlphaNum 32) (b64dec $prevUiClientSecret) -}}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Fix https://github.com/epinio/epinio/issues/2085

The check was done on the entire `dexSecret` instead of the `uiClientSecret` value. So it was always true and it was trying to add a blank value.