### PR TITLE
check domain value in chart

### DIFF
--- a/chart/epinio/templates/chart-validations.yaml
+++ b/chart/epinio/templates/chart-validations.yaml
@@ -1,3 +1,6 @@
 {{- if (and .Values.minio.enabled .Values.s3gw.enabled) }}
 {{- fail "use either minio or s3gw" }}
 {{- end }}
+{{- if (empty .Values.global.domain) }}
+{{- fail "domain cannot be empty" }}
+{{- end }}


### PR DESCRIPTION
If global.domain is empty the helm installation will fail with the message: "domain cannot be empty".

```
helm install --generate-name=true --namespace=default --timeout=10m0s --values=/home/shell/helm/values-epinio-1.6.2.yaml --version=1.6.2 --wait=true /home/shell/helm/epinio-1.6.2.tgz
creating 1 resource(s)
creating 1 resource(s)
creating 1 resource(s)
Error: INSTALLATION FAILED: execution error at (epinio/templates/chart-validations.yaml:5:4): domain cannot be empty

```