### PR TITLE
Fixed epinio-ui deployment with disabled dex

### DIFF
--- a/chart/epinio-ui/Chart.yaml
+++ b/chart/epinio-ui/Chart.yaml
@@ -15,4 +15,4 @@ name: epinio-ui
 sources:
 - https://github.com/epinio/ui
 type: application
-version: 1.7.0
+version: 1.7.1

--- a/chart/epinio-ui/templates/server.yaml
+++ b/chart/epinio-ui/templates/server.yaml
@@ -50,17 +50,19 @@ spec:
           value: {{ default (printf "https://epinio.%s" .Values.global.domain) .Values.epinioUI.uiURL }}
         - name: EPINIO_API_SKIP_SSL
           value: {{ (default "false" .Values.epinioUI.apiSkipSSL) | quote }}
-        - name: EPINIO_DEX_AUTH_URL
-          value: {{ default (printf "https://auth.%s" .Values.global.domain) .Values.epinioUI.dexURL }}
         - name: EPINIO_THEME
           value: {{ (default "light" .Values.epinioUI.theme) | quote }}
+        {{- if .Values.global.dex.enabled }}
+        - name: EPINIO_DEX_AUTH_URL
+          value: {{ default (printf "https://auth.%s" .Values.global.domain) .Values.epinioUI.dexURL }}
         - name: EPINIO_DEX_ENABLED
-          value: {{ (default false .Values.global.dex.enabled) | quote }}
+          value: "true"
         - name: EPINIO_DEX_SECRET
           valueFrom:
             secretKeyRef:
               name: dex-config
               key: uiClientSecret
+        {{- end }}
         - name: HTTP_CLIENT_TIMEOUT_IN_SECS
           value: "120"
         - name: SESSION_STORE_SECRET


### PR DESCRIPTION
Fix: https://github.com/epinio/ui/issues/176

The `epinio-ui` deployment was failing because of the missing `dex-config` secret when Dex is disabled.

This PR wraps and removes the `EPINIO_DEX_*` environment variables when Dex is not enabled.

It also bumps the `epinio-ui` chart that can be used by the Epinio one.