### PR TITLE
Enable the ability for deleting storage for registry subchart

### DIFF
--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -133,8 +133,6 @@ spec:
         image: "{{ template "registry-url" . }}{{ .Values.containerregistry.image.registry.repository}}:{{ .Values.containerregistry.image.registry.tag }}"
         imagePullPolicy: {{ .Values.containerregistry.imagePullPolicy }}
         env:
-        - name: REGISTRY_STORAGE_DELETE_ENABLED
-          value: true
         - name: REGISTRY_AUTH
           value: htpasswd
         - name: REGISTRY_AUTH_HTPASSWD_REALM
@@ -145,6 +143,8 @@ spec:
           value: "/certs/tls.crt"
         - name: REGISTRY_HTTP_TLS_KEY
           value: "/certs/tls.key"
+        - name: REGISTRY_STORAGE_DELETE_ENABLED
+          value: true
         volumeMounts:
         - name: registry
           mountPath: /var/lib/registry

--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -133,6 +133,8 @@ spec:
         image: "{{ template "registry-url" . }}{{ .Values.containerregistry.image.registry.repository}}:{{ .Values.containerregistry.image.registry.tag }}"
         imagePullPolicy: {{ .Values.containerregistry.imagePullPolicy }}
         env:
+        - name: REGISTRY_STORAGE_DELETE_ENABLED
+          value: true
         - name: REGISTRY_AUTH
           value: htpasswd
         - name: REGISTRY_AUTH_HTPASSWD_REALM

--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -144,7 +144,7 @@ spec:
         - name: REGISTRY_HTTP_TLS_KEY
           value: "/certs/tls.key"
         - name: REGISTRY_STORAGE_DELETE_ENABLED
-          value: true
+          value: "true"
         volumeMounts:
         - name: registry
           mountPath: /var/lib/registry


### PR DESCRIPTION
It would be very nice to enabled to delete registry images via API or via a registry ui by simply be able to deploy:
```
epinio push --container-image-url parabuzzle/craneoperator:latest --name registry \
   -e REGISTRY_HOST=registry.epinio.svc.cluster.local \
   -e REGISTRY_PORT=5000 -e REGISTRY_PROTOCOL=https \
   -e SSL_VERIFY=false -e USERNAME=admin -e PASSWORD=changeme \
   -e REGISTRY_USERNAME=admin -e REGISTRY_PASSWORD=changeme \
   -e REGISTRY_ALLOW_DELETE=true
```

using epinio push with docker

