### PR TITLE
Allow to override default application port

### DIFF
--- a/chart/application-stateful/Chart.yaml
+++ b/chart/application-stateful/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.21
+version: 0.1.22-rc1
 keywords:
 - epinio
 - paas

--- a/chart/application-stateful/templates/_helpers.tpl
+++ b/chart/application-stateful/templates/_helpers.tpl
@@ -48,3 +48,10 @@ character removed.
 {{- define "epinio-truncate" -}}
 {{ print "r-" (sha1sum .) }}
 {{- end }}
+
+{{/*
+Application listening port
+*/}}
+{{- define "epinio-app-listening-port" -}}
+{{ .Values.userConfig.appListeningPort | default 8080 }}
+{{- end }}

--- a/chart/application-stateful/templates/service.yaml
+++ b/chart/application-stateful/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: 8080
+      targetPort: {{ include "epinio-app-listening-port" . }}
   selector:
     {{- include "epinio-application.selectorLabels" . | nindent 4 }}
   type: ClusterIP

--- a/chart/application-stateful/templates/statefulset.yaml
+++ b/chart/application-stateful/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: {{ include "epinio-truncate" .Values.epinio.appName }}
         ports:
-        - containerPort: 8080
+        - containerPort: {{ include "epinio-app-listening-port" . }}
           protocol: TCP
         {{- with .Values.epinio.configurations }}
         volumeMounts:
@@ -55,7 +55,7 @@ spec:
         {{- end }}
         env:
         - name: PORT
-          value: "8080"
+          value: {{ include "epinio-app-listening-port" . | quote }}
         {{- range .Values.epinio.env }}
         - name: {{ .name | quote }}
           value: {{ .value | quote }}

--- a/chart/application-stateful/values.yaml
+++ b/chart/application-stateful/values.yaml
@@ -62,3 +62,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+userConfig: {}

--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.24
+version: 0.1.25-rc1
 keywords:
 - epinio
 - paas

--- a/chart/application/templates/_helpers.tpl
+++ b/chart/application/templates/_helpers.tpl
@@ -48,3 +48,10 @@ character removed.
 {{- define "epinio-truncate" -}}
 {{ print "r" (trunc 21 (include "epinio-name-sanitize" .)) "-" (sha1sum .) }}
 {{- end }}
+
+{{/*
+Application listening port
+*/}}
+{{- define "epinio-app-listening-port" -}}
+{{ .Values.userConfig.appListeningPort | default 8080 }}
+{{- end }}

--- a/chart/application/templates/deployment.yaml
+++ b/chart/application/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       - name: {{ include "epinio-truncate" .Values.epinio.appName }}
         ports:
-        - containerPort: 8080
+        - containerPort: {{ include "epinio-app-listening-port" . }}
           protocol: TCP
         {{- with .Values.epinio.configpaths }}
         volumeMounts:
@@ -52,7 +52,7 @@ spec:
         {{- end }}
         env:
         - name: PORT
-          value: "8080"
+          value: {{ include "epinio-app-listening-port" . | quote }}
         {{- range .Values.epinio.env }}
         - name: {{ .name | quote }}
           value: {{ .value | quote }}

--- a/chart/application/templates/service.yaml
+++ b/chart/application/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   ports:
     - port: 8080
       protocol: TCP
-      targetPort: 8080
+      targetPort: {{ include "epinio-app-listening-port" . }}
   selector:
     {{- include "epinio-application.selectorLabels" . | nindent 4 }}
   type: ClusterIP

--- a/chart/application/values.yaml
+++ b/chart/application/values.yaml
@@ -70,3 +70,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+userConfig: {}

--- a/chart/epinio/templates/default-app-chart.yaml
+++ b/chart/epinio/templates/default-app-chart.yaml
@@ -13,3 +13,7 @@ spec:
   shortDescription: Epinio standard deployment
   description: Epinio standard support chart for application deployment
   helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.24/epinio-application-0.1.24.tgz
+  settings:
+    appListeningPort:
+      type: 'integer'
+      minimum: '1001'


### PR DESCRIPTION
### Specify a custom listening port for an application (#1792)
User can now specify a custom listening port for an Epinio application.
The port is pushed inside the application container via the environment
variable: `PORT`.
The value defaults to 8080; it can be specified using a custom chart value
during the application's push:

`epinio push -n 'app-name' --chart-value 'appListeningPort=8087'`

Valid appListeningPort values range from `1001` to `(2^16)-1`

Fixes: https://github.com/epinio/epinio/issues/1792