### PR TITLE
Removed not yet available settings in default AppChart

### DIFF
--- a/chart/epinio/templates/default-app-chart.yaml
+++ b/chart/epinio/templates/default-app-chart.yaml
@@ -13,7 +13,3 @@ spec:
   shortDescription: Epinio standard deployment
   description: Epinio standard support chart for application deployment
   helmChart: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.24/epinio-application-0.1.24.tgz
-  settings:
-    appListeningPort:
-      type: 'integer'
-      minimum: '1001'


### PR DESCRIPTION
This settings are shown in the `epinio app chart list|show` and some tests are failing.

Since we are still pointing to the old chart and those are not available there we should add them later on.