### PR TITLE
Bump application chart versions

### DIFF
--- a/chart/application-stateful/Chart.yaml
+++ b/chart/application-stateful/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.22-rc1
+version: 0.1.22
 keywords:
 - epinio
 - paas

--- a/chart/application/Chart.yaml
+++ b/chart/application/Chart.yaml
@@ -4,7 +4,7 @@ description: The helm chart for epinio applications to be deployed by
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 home: https://github.com/epinio/epinio
 type: application
-version: 0.1.25-rc1
+version: 0.1.25
 keywords:
 - epinio
 - paas


### PR DESCRIPTION
- application chart: `0.1.25`
- stateful chart: `0.1.22`

Addresses: https://github.com/epinio/epinio/issues/1792
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>