### PR TITLE
Fix hardcoded epinio ns for image-export-pvc

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -359,7 +359,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: image-export-pvc
-  namespace: epinio
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Manuel found this issue when installing epinio into a custom namespace in rancher.

Without this fix helm timeouts on `PersistentVolumeClaim is not bound: epinio/image-export-pvc`.

With this fix I was able to install epinio into custom ns and also deploy an app.