### PR TITLE
fix: make env variables directly availabe to creator, not just creator's children

### DIFF
--- a/chart/epinio/templates/stage-scripts.yaml
+++ b/chart/epinio/templates/stage-scripts.yaml
@@ -83,6 +83,7 @@ data:
       exit 1
     fi
     find /workspace
+    for path in /workspace/source/env/* ; do export $(basename ${path})=$(cat $path) ; done
     /cnb/lifecycle/creator \
       -app=/workspace/source/app \
       -cache-dir=/workspace/cache \


### PR DESCRIPTION
note: required for http(s) proxy setup, as the creator also performs net pulls, not just the called packs.

Ref https://github.com/epinio/epinio/pull/2197 for import into E