### PR TITLE
Fix Updatecli updates

### DIFF
--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -39,20 +39,6 @@ conditions:
       architecture: "amd64"
 
 targets:
-  epinio-ui-chart:
-    name: "Update Epinio UI backend image for Helm Chart chart/epinio-ui"
-    kind: "helmchart"
-    scmid: "helm-charts"
-    transformers:
-      - addprefix: "ghcr.io/epinio/epinio-ui:"
-    spec:
-      name: "chart/epinio-ui"
-      file: "values.yaml"
-      key: "epinioUI.image.tag"
-      value: '{{ source "ui-backend-tag" }}'
-      versionincrement: minor
-      appversion: true
-
   epinio-chart:
     name: "Update Epinio UI backend image for Helm Chart chart/epinio"
     kind: "helmchart"
@@ -64,8 +50,8 @@ targets:
       file: "values.yaml"
       key: "image.epinio-ui.tag"
       value: '{{ source "ui-backend-tag" }}'
-      versionincrement: minor
-      appversion: true
+      versionincrement: none
+      appversion: false
 
 # Define pullrequest configuration if one needs to be created
 actions:

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -77,4 +77,4 @@ targets:
       name: "chart/epinio"
       file: "Chart.yaml"
       key: "appVersion"
-      versionincrement: "minor"
+      versionincrement: "none"


### PR DESCRIPTION
This PR will turn off the updates of the `epinio-ui` chart (merged into the `epinio` one).

This is also turning off the autoincrement of the Chart.yaml to avoid having multiple bumps to unexpected version while having multiple updates (i.e.: updating the UI will bump to from `1.7.0` to `1.8.0`. And then the Epinio server will also be updated and the version will bump again from `1.8.0` to `1.9.0`.