### PR TITLE
Narrow down self-hosted runner usage

### DIFF
--- a/.github/workflows/build-epiniod.yml
+++ b/.github/workflows/build-epiniod.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 jobs:
   build-image:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Use ubuntu-latest where possible, before switching self-hosted runners to be created on GCP. 