### PR TITLE
Added `containerregistry.certificateSecret` value

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -309,6 +309,9 @@ spec:
             {{- if .Values.containerregistry.enabled }}
             - name: REGISTRY_CERTIFICATE_SECRET
               value: "epinio-registry-tls"
+            {{- else if .Values.containerregistry.certificateSecret  }}
+            - name: REGISTRY_CERTIFICATE_SECRET
+              value: {{ .Values.containerregistry.certificateSecret }}
             {{- end }}
             {{- if .Values.server.ingressClassName }}
             - name: INGRESS_CLASS_NAME

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -187,6 +187,10 @@ containerregistry:
   # The ingressClassName is used to select the ingress controller. If
   # empty no class will be added to the ingresses.
   ingressClassName: ""
+  # The certificateSecret is used to load the certificate of the registry in the staging job.
+  # The certificate has to be in PEM format within in a 'tls.crt' key (it can be an Opaque secret).
+  # It also has to be trusted by the kubelet, and it needs to be added in the cluster as well.
+  certificateSecret: ""
 
 serviceCatalog:
   # Enable service catalog service for development


### PR DESCRIPTION
This PR adds the `containerregistry.certificateSecret` value.

This can be used to specify the secret containing the certificate of an external registry, that needs to be trusted by the staging job.