### PR TITLE
Added `strategy` to Epinio deployment

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -246,6 +246,10 @@ spec:
       app.kubernetes.io/instance: default
       app.kubernetes.io/name: epinio-server
       app.kubernetes.io/part-of: epinio
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -64,6 +64,15 @@ service:
   # -- Annotations to be added to the Epinio service.
   annotations: {}
 
+# The strategy used to deploy the Epinio server.
+# If you are using a RWO storage the following will avoid a Multi-Attach error during an `helm upgrade`.
+# See https://github.com/epinio/epinio/issues/2253.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1
+
 certManagerNamespace: cert-manager
 
 # Connection details for the S3 storage


### PR DESCRIPTION
This PR adds an optional `strategy` values that can be used to decide the deployment strategy of the Epinio server.

Using a `maxSurge=0` and a maxUnavailable=1` will fix the `MultiAttach` error while using some RWO storage.

Fixes https://github.com/epinio/epinio/issues/2253