### PR TITLE
Fixed some `updatecli` issues

### DIFF
--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -43,12 +43,10 @@ targets:
     name: "Update Epinio UI backend image for Helm Chart chart/epinio"
     kind: "helmchart"
     scmid: "helm-charts"
-    transformers:
-      - addprefix: "ghcr.io/epinio/epinio-ui:"
     spec:
       name: "chart/epinio"
       file: "values.yaml"
-      key: "image.epinio-ui.tag"
+      key: "$.image.epinio-ui.tag"
       value: '{{ source "ui-backend-tag" }}'
       versionincrement: none
       appversion: false

--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -54,7 +54,7 @@ conditions:
     scmid: "helm-charts"
     spec:
       file: "chart/epinio/values.yaml"
-      key: "image.epinio.repository"
+      key: "$.image.epinio.repository"
       value: "epinio/epinio-server"
 
   dockerImageRegistry:
@@ -64,7 +64,7 @@ conditions:
     scmid: "helm-charts"
     spec:
       file: "chart/epinio/values.yaml"
-      key: "image.epinio.registry"
+      key: "$.image.epinio.registry"
       value: "ghcr.io/"
 
 # Defines what needs to be udpated if needed
@@ -76,5 +76,5 @@ targets:
     spec:
       name: "chart/epinio"
       file: "Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
       versionincrement: "none"


### PR DESCRIPTION
Removed some deprecation warnings, and removed transformer (maybe needed for a bug in a previous `updatecli` version).

Ref: https://github.com/epinio/helm-charts/pull/429