### PR TITLE
Allow Epinio pre-releases

### DIFF
--- a/updatecli/updatecli.d/epinio.yaml
+++ b/updatecli/updatecli.d/epinio.yaml
@@ -37,6 +37,7 @@ sources:
       path: "./epinio/"
       versionfilter:
         kind: semver
+        pattern: ">=0.0.0-0"
 
 # Defines condition that must pass in order to update targets
 conditions:


### PR DESCRIPTION
As explained on https://github.com/Masterminds/semver#checking-version-constraints

> When constraint checking is used for checks or validation it will follow a different set of rules that are common for ranges with tools like npm/js and Rust/Cargo. This includes considering prereleases to be invalid if the ranges does not include one. If you want to have it include pre-releases a simple solution is to include -0 in your range.