### PR TITLE
fix: bump skopeo, 1.10 image is expired.

### DIFF
--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -26,7 +26,7 @@ image:
   skopeo:
     registry: quay.io/
     repository: skopeo/stable
-    tag: v1.10
+    tag: v1.13.2
   kubectl:
     repository: rancher/kubectl
     tag: v1.22.6


### PR DESCRIPTION
ref https://github.com/epinio/epinio/issues/2528
ref https://github.com/epinio/epinio/pull/2529 (imports this PR)