### PR TITLE
Updated Service CRD to support private Helm repositories and registries

### DIFF
--- a/chart/epinio/crds/service-crd.yaml
+++ b/chart/epinio/crds/service-crd.yaml
@@ -59,6 +59,8 @@ spec:
                 properties:
                   name:
                     type: string
+                  secret:
+                    type: string
                   url:
                     type: string
                 type: object

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -264,6 +264,8 @@ spec:
       volumes:
       - name: tmp-volume
         emptyDir: {}
+      - name: config-volume
+        emptyDir: {}
       - name: image-export-volume
         persistentVolumeClaim:
           claimName: image-export-pvc
@@ -356,6 +358,8 @@ spec:
           volumeMounts:
           - name: tmp-volume
             mountPath: /tmp
+          - name: config-volume
+            mountPath: /.config
           - name: image-export-volume
             mountPath: /image-export
 {{- if .Values.global.dex.enabled }}


### PR DESCRIPTION
This PR updates the Service CRD (https://github.com/epinio/application/pull/14) and makes `/.config` folder writable. This folder is needed by the Helm client to login and store the credentials of the OCI registries.