### PR TITLE
Added 'adminPassword', 'epinioPassword', and 'password' values

### DIFF
--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -56,15 +56,9 @@ questions:
     - "epinio-ca"
     - "selfsigned-issuer"
     - "letsencrypt-production"
-- variable: api.username
-  label: API username
-  description: "The user name for authenticating all API requests"
-  type: string
-  required: false
-  group: "General settings"
-- variable: api.passwordBcrypt
-  label: API password
-  description: "The password for authenticating all API requests (hashed with Bcrypt)"
+- variable: api.adminPassword
+  label: API password for the 'admin' user
+  description: "The password of the 'admin' user"
   type: password
   required: false
   group: "General settings"

--- a/chart/epinio/templates/default-user.yaml
+++ b/chart/epinio/templates/default-user.yaml
@@ -11,7 +11,15 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 stringData:
   username: {{ .username | quote }}
+  {{- if (and $.Values.api.adminPassword (eq .username "admin" )) }}
+  password: {{ bcrypt $.Values.api.adminPassword | quote }}
+  {{- else if (and $.Values.api.epinioPassword (eq .username "epinio" )) }}
+  password: {{ bcrypt $.Values.api.epinioPassword | quote }}
+  {{- else if .passwordBcrypt }}
   password: {{ .passwordBcrypt | quote }}
+  {{- else if .password }}
+  password: {{ bcrypt .password | quote }}
+  {{- end }}
   namespaces: |
     {{ join "\n" .workspaces -}}
 {{- end }}

--- a/chart/epinio/values.schema.json
+++ b/chart/epinio/values.schema.json
@@ -141,6 +141,14 @@
       "description": "API access configuration",
       "type": "object",
       "properties": {
+        "adminPassword": {
+          "description": "The cleartext password for the 'admin' user",
+          "type": "string"
+        },
+        "epinioPassword": {
+          "description": "The cleartext password for the 'epinio' user",
+          "type": "string"
+        },
         "users": {
           "description": "Default Epinio users",
           "type": "array",
@@ -151,6 +159,9 @@
                 "type": "string"
               },
               "passwordBcrypt": {
+                "type": "string"
+              },
+              "password": {
                 "type": "string"
               },
               "role": {
@@ -165,7 +176,6 @@
             },
             "required": [
               "username",
-              "passwordBcrypt",
               "role"
             ]
           }

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -86,11 +86,18 @@ s3:
   certificateSecret: ""
 api:
   # Default users
+  # plain password used for the 'admin' user
+  adminPassword: ""
+  # plain password used for the 'epinio' user
+  epinioPassword: ""
   users:
     - username: admin
-      passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+      password: password
+      # or you can provide an already bcrypt hashed password
+      # passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
       role: admin
     - username: epinio
+      # the Bcrypt hash for the `password` password
       passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
       role: user
       workspaces:


### PR DESCRIPTION
This PR adds the 'api.adminPassword', 'api.epinioPassword' fields to specifiy the cleartext password for the `admin` and `epinio` user. This password will be then hashed with Bcrypt.

In the same way now also a `password` field was added in the `api.users` object.

If the `adminPassword` or the `epinioPassword` are specified they will have priority over the `passwordBcrypt` or `password` fields. Otherwise the `passwordBcrypt` has priority over the `password` field.

In the Rancher `question.yaml` the `api.username` or the `api.passwordBcrypt` fields were not working, probably a leftover of the initial fixed user to the users array refactor. Now the `adminPassword` field can be specified, but we don't have a way to provide the username of the defaul/admin user.