### PR TITLE
Install `letsencrypt-[staging|production]` ClusterIssuer only when required

### DIFF
--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -55,6 +55,7 @@ questions:
   options:
     - "epinio-ca"
     - "selfsigned-issuer"
+    - "letsencrypt-staging"
     - "letsencrypt-production"
 - variable: api.adminPassword
   label: API password for the 'admin' user

--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -40,7 +40,7 @@ questions:
   group: "General settings"
   show_subquestion_if: true
   subquestions:
-  - variable: customTlsIssuer
+  - variable: global.customTlsIssuer
     label: TLS issuer
     description: "Name of the cluster issuer to use"
     type: string

--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -17,7 +17,7 @@ spec:
   ca:
     secretName: epinio-ca-root
 
-{{- if eq .Values.tlsIssuer "letsencrypt-production" }}
+{{- if eq .Values.global.tlsIssuer "letsencrypt-production" }}
 ---
 # Let's encrypt production issuer
 apiVersion: cert-manager.io/v1
@@ -43,7 +43,7 @@ spec:
                 traefik.ingress.kubernetes.io/router.entrypoints: websecure
                 traefik.ingress.kubernetes.io/router.tls: "true"
 
-{{- else if eq .Values.tlsIssuer "letsencrypt-staging" }}
+{{- else if eq .Values.global.tlsIssuer "letsencrypt-staging" }}
 ---
 # Let's encrypt staging issuer
 apiVersion: cert-manager.io/v1

--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -43,4 +43,29 @@ spec:
                 traefik.ingress.kubernetes.io/router.entrypoints: websecure
                 traefik.ingress.kubernetes.io/router.tls: "true"
 
+{{- else if eq .Values.tlsIssuer "letsencrypt-staging" }}
+---
+# Let's encrypt staging issuer
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: {{ .Values.global.tlsIssuerEmail | default .Values.email | quote }}
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - http01:
+        ingress:
+          {{- if .Values.ingress.ingressClassName }}
+          class: "{{ .Values.ingress.ingressClassName }}"
+          {{- end }}
+          ingressTemplate:
+            metadata:
+              annotations:
+                traefik.ingress.kubernetes.io/router.entrypoints: websecure
+                traefik.ingress.kubernetes.io/router.tls: "true"
+
 {{- end }}

--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -8,6 +8,17 @@ spec:
   selfSigned: {}
 
 ---
+# Private CA (epinio-ca) issuer
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: epinio-ca
+spec:
+  ca:
+    secretName: epinio-ca-root
+
+{{- if eq .Values.tlsIssuer "letsencrypt-production" }}
+---
 # Let's encrypt production issuer
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -32,13 +43,4 @@ spec:
                 traefik.ingress.kubernetes.io/router.entrypoints: websecure
                 traefik.ingress.kubernetes.io/router.tls: "true"
 
----
-# Private CA (epinio-ca) issuer
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: epinio-ca
-spec:
-  ca:
-    secretName: epinio-ca-root
-
+{{- end }}

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -215,7 +215,7 @@ global:
   # Used in registry path when pushing -> "external.tld/apps/APPNAME"
   registryNamespace: "apps"
   # The name of the cluster issuer to use.
-  # Epinio creates three options: 'epinio-ca', 'letsencrypt-production', and 'selfsigned-issuer'.
+  # Epinio creates three options: 'epinio-ca', 'selfsigned-issuer', 'letsencrypt-staging' and 'letsencrypt-production'.
   tlsIssuer: "epinio-ca"
   # The name of your ClusterIssuer (it will override the tlsIssuer)
   customTlsIssuer: ""

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -217,8 +217,10 @@ global:
   # The name of the cluster issuer to use.
   # Epinio creates three options: 'epinio-ca', 'letsencrypt-production', and 'selfsigned-issuer'.
   tlsIssuer: "epinio-ca"
+  # The name of your ClusterIssuer (it will override the tlsIssuer)
+  customTlsIssuer: ""
   # Email address to receive the certificate notification emails send by the `letsencrypt-production` issuer.
-  tlsIssuerEmail: "epinio@suse.com"
+  tlsIssuerEmail: ""
   # The URL of the container registry from where to pull container images for the various
   # created Pods. Don't confuse this registry with the "Epinio registry" which is the one
   # where Epinio stores the application images.


### PR DESCRIPTION
Fix #479 

This PR avoid the installation of the `letsencrypt-production` when not needed. It will be created only when the tlsIssuer value is set. It also adds the staging issuer, and fixes a couple of wrong questions values during the Rancher installation.