### PR TITLE
Fix missing `customTlsIssuer` for workloads and epinio-ui

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -288,7 +288,7 @@ spec:
             - name: EPINIO_TIMEOUT_MULTIPLIER
               value: "{{ .Values.server.timeoutMultiplier }}"
             - name: TLS_ISSUER
-              value: "{{ .Values.global.tlsIssuer }}"
+              value: "{{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer }}"
             - name: TRACE_LEVEL
               value: "{{ .Values.server.traceLevel }}"
             - name: CHART_VERSION

--- a/chart/epinio/templates/ui/certificate.yaml
+++ b/chart/epinio/templates/ui/certificate.yaml
@@ -10,6 +10,6 @@ spec:
   - {{ .Values.global.domain }}
   issuerRef:
     kind: ClusterIssuer
-    name: {{ .Values.global.tlsIssuer }}
+    name: {{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer }}
   secretName: epinio-ui-tls
 {{- end }}


### PR DESCRIPTION
Fix https://github.com/epinio/epinio/issues/2564

Fix missing `customTlsIssuer` for workloads and epinio-ui.