### PR TITLE
remove traefik annotations for cluster issuer ingresses

### DIFF
--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -40,8 +40,6 @@ spec:
           ingressTemplate:
             metadata:
               annotations:
-                traefik.ingress.kubernetes.io/router.entrypoints: websecure
-                traefik.ingress.kubernetes.io/router.tls: "true"
 
 {{- else if eq .Values.global.tlsIssuer "letsencrypt-staging" }}
 ---
@@ -65,7 +63,5 @@ spec:
           ingressTemplate:
             metadata:
               annotations:
-                traefik.ingress.kubernetes.io/router.entrypoints: websecure
-                traefik.ingress.kubernetes.io/router.tls: "true"
 
 {{- end }}


### PR DESCRIPTION
fix #482 

this requires testing with LE to ensure that the removal of the annotations has not broken LE.
Well, according to the issue it should unbreak it.
In other words, LE should be broken without the change. That should be tested as well.
The issue ticket unfortunately does not say which cluster was used underneath.
