### PR TITLE
experimental excision of cert-manager

### DIFF
--- a/chart/epinio/templates/cert-secrets.yaml
+++ b/chart/epinio/templates/cert-secrets.yaml
@@ -8,9 +8,9 @@ metadata:
   name: epinio-registry-tls
   namespace: {{ .Release.Namespace }}
 stringData:
-  ca.crt: {{ .values.certManager.registry.ca | quote }}
-  tls.key: {{ .values.certManager.registry.key | quote }}
-  tls.crt: {{ .values.certManager.registry.cert | quote }}
+  ca.crt: {{ .Values.certManager.registry.ca | quote }}
+  tls.key: {{ .Values.certManager.registry.key | quote }}
+  tls.crt: {{ .Values.certManager.registry.cert | quote }}
 ---
 apiVersion: v1
 kind: Secret
@@ -20,9 +20,9 @@ metadata:
   name: epinio-tls
   namespace: {{ .Release.Namespace }}
 stringData:
-  ca.crt: {{ .values.certManager.epinio.ca | quote }}
-  tls.key: {{ .values.certManager.epinio.key | quote }}
-  tls.crt: {{ .values.certManager.epinio.cert | quote }}
+  ca.crt: {{ .Values.certManager.epinio.ca | quote }}
+  tls.key: {{ .Values.certManager.epinio.key | quote }}
+  tls.crt: {{ .Values.certManager.epinio.cert | quote }}
 ---
 apiVersion: v1
 kind: Secret
@@ -32,9 +32,9 @@ metadata:
   name: epinio-ca-root
   namespace: {{ .Release.Namespace }}
 stringData:
-  ca.crt: {{ .values.certManager.caRoot.ca | quote }}
-  tls.key: {{ .values.certManager.caRoot.key | quote }}
-  tls.crt: {{ .values.certManager.caRoot.cert | quote }}
+  ca.crt: {{ .Values.certManager.caRoot.ca | quote }}
+  tls.key: {{ .Values.certManager.caRoot.key | quote }}
+  tls.crt: {{ .Values.certManager.caRoot.cert | quote }}
 {{- if .Values.global.dex.enabled }}
 ---
 apiVersion: v1
@@ -45,9 +45,9 @@ metadata:
   name: dex-tls
   namespace: {{ .Release.Namespace }}
 stringData:
-  ca.crt:  {{ .values.certManager.dex.ca   | default .values.certManager.epinio.ca   | quote }}
-  tls.key: {{ .values.certManager.dex.key  | default .values.certManager.epinio.key  | quote }}
-  tls.crt: {{ .values.certManager.dex.cert | default .values.certManager.epinio.cert | quote }}
+  ca.crt:  {{ .Values.certManager.dex.ca   | default .Values.certManager.epinio.ca   | quote }}
+  tls.key: {{ .Values.certManager.dex.key  | default .Values.certManager.epinio.key  | quote }}
+  tls.crt: {{ .Values.certManager.dex.cert | default .Values.certManager.epinio.cert | quote }}
 {{- end }}
 {{- if and .Values.epinioUI.enabled .Values.epinioUI.ingress.enabled }}
 ---
@@ -59,9 +59,9 @@ metadata:
   name: epinio-ui-tls
   namespace: {{ .Release.Namespace }}
 stringData:
-  ca.crt:  {{ .values.certManager.ui.ca   | default .values.certManager.epinio.ca   | quote }}
-  tls.key: {{ .values.certManager.ui.key  | default .values.certManager.epinio.key  | quote }}
-  tls.crt: {{ .values.certManager.ui.cert | default .values.certManager.epinio.cert | quote }}
+  ca.crt:  {{ .Values.certManager.ui.ca   | default .Values.certManager.epinio.ca   | quote }}
+  tls.key: {{ .Values.certManager.ui.key  | default .Values.certManager.epinio.key  | quote }}
+  tls.crt: {{ .Values.certManager.ui.cert | default .Values.certManager.epinio.cert | quote }}
 {{- end }}
 {{- if .Values.minio.enabled }}
 ---
@@ -73,9 +73,9 @@ metadata:
   name: minio-tls
   namespace: {{ .Release.Namespace }}
 stringData:
-  ca.crt: {{ .values.certManager.s3.ca | quote }}
-  tls.key: {{ .values.certManager.s3.key | quote }}
-  tls.crt: {{ .values.certManager.s3.cert | quote }}
+  ca.crt: {{ .Values.certManager.s3.ca | quote }}
+  tls.key: {{ .Values.certManager.s3.key | quote }}
+  tls.crt: {{ .Values.certManager.s3.cert | quote }}
 {{- else if .Values.s3gw.enabled }}
 ---
 apiVersion: v1
@@ -86,8 +86,8 @@ metadata:
   name: s3gw-cluster-ip-tls
   namespace: {{ .Release.Namespace }}
 stringData:
-  ca.crt: {{ .values.certManager.s3.ca | quote }}
-  tls.key: {{ .values.certManager.s3.key | quote }}
-  tls.crt: {{ .values.certManager.s3.cert | quote }}
+  ca.crt: {{ .Values.certManager.s3.ca | quote }}
+  tls.key: {{ .Values.certManager.s3.key | quote }}
+  tls.crt: {{ .Values.certManager.s3.cert | quote }}
 {{- end }}
 {{- end }}

--- a/chart/epinio/templates/cert-secrets.yaml
+++ b/chart/epinio/templates/cert-secrets.yaml
@@ -29,19 +29,6 @@ kind: Secret
 type: kubernetes.io/tls
 metadata:
   annotations:
-  name: epinio-ca-root
-  namespace: {{ .Release.Namespace }}
-stringData:
-  ca.crt: {{ .Values.certManager.caRoot.ca | quote }}
-  tls.key: {{ .Values.certManager.caRoot.key | quote }}
-  tls.crt: {{ .Values.certManager.caRoot.cert | quote }}
-{{- if .Values.global.dex.enabled }}
----
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/tls
-metadata:
-  annotations:
   name: dex-tls
   namespace: {{ .Release.Namespace }}
 stringData:

--- a/chart/epinio/templates/cert-secrets.yaml
+++ b/chart/epinio/templates/cert-secrets.yaml
@@ -24,6 +24,7 @@ stringData:
   tls.key: {{ .Values.certManager.epinio.key | quote }}
   tls.crt: {{ .Values.certManager.epinio.cert | quote }}
 ---
+{{- if .Values.global.dex.enabled }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls

--- a/chart/epinio/templates/cert-secrets.yaml
+++ b/chart/epinio/templates/cert-secrets.yaml
@@ -1,0 +1,93 @@
+{{- if not .Values.certManager.enabled }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+  name: epinio-registry-tls
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ca.crt: {{ .values.certManager.registry.ca | quote }}
+  tls.key: {{ .values.certManager.registry.key | quote }}
+  tls.crt: {{ .values.certManager.registry.cert | quote }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+  name: epinio-tls
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ca.crt: {{ .values.certManager.epinio.ca | quote }}
+  tls.key: {{ .values.certManager.epinio.key | quote }}
+  tls.crt: {{ .values.certManager.epinio.cert | quote }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+  name: epinio-ca-root
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ca.crt: {{ .values.certManager.caRoot.ca | quote }}
+  tls.key: {{ .values.certManager.caRoot.key | quote }}
+  tls.crt: {{ .values.certManager.caRoot.cert | quote }}
+{{- if .Values.global.dex.enabled }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+  name: dex-tls
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ca.crt:  {{ .values.certManager.dex.ca   | default .values.certManager.epinio.ca   | quote }}
+  tls.key: {{ .values.certManager.dex.key  | default .values.certManager.epinio.key  | quote }}
+  tls.crt: {{ .values.certManager.dex.cert | default .values.certManager.epinio.cert | quote }}
+{{- end }}
+{{- if and .Values.epinioUI.enabled .Values.epinioUI.ingress.enabled }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+  name: epinio-ui-tls
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ca.crt:  {{ .values.certManager.ui.ca   | default .values.certManager.epinio.ca   | quote }}
+  tls.key: {{ .values.certManager.ui.key  | default .values.certManager.epinio.key  | quote }}
+  tls.crt: {{ .values.certManager.ui.cert | default .values.certManager.epinio.cert | quote }}
+{{- end }}
+{{- if .Values.minio.enabled }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+  name: minio-tls
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ca.crt: {{ .values.certManager.s3.ca | quote }}
+  tls.key: {{ .values.certManager.s3.key | quote }}
+  tls.crt: {{ .values.certManager.s3.cert | quote }}
+{{- else if .Values.s3gw.enabled }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+  name: s3gw-cluster-ip-tls
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ca.crt: {{ .values.certManager.s3.ca | quote }}
+  tls.key: {{ .values.certManager.s3.key | quote }}
+  tls.crt: {{ .values.certManager.s3.cert | quote }}
+{{- end }}
+{{- end }}

--- a/chart/epinio/templates/certificate.yaml
+++ b/chart/epinio/templates/certificate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -48,3 +49,4 @@ spec:
     algorithm: ECDSA
     size: 256
   secretName: epinio-ca-root
+{{- end }}

--- a/chart/epinio/templates/cluster-issuers.yaml
+++ b/chart/epinio/templates/cluster-issuers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certManager.enabled }}
 ---
 # Self-signed issuer
 apiVersion: cert-manager.io/v1
@@ -64,4 +65,5 @@ spec:
             metadata:
               annotations:
 
+{{- end }}
 {{- end }}

--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -9,6 +9,7 @@ stringData:
   # The only supported password format is bcrypt
   htpasswd:  {{ htpasswd .Values.global.registryUsername .Values.global.registryPassword | quote }}
 
+{{- if .Values.certManager.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -24,6 +25,7 @@ spec:
     kind: ClusterIssuer
     name: epinio-ca
   secretName: epinio-registry-tls
+{{- end }}
 
 ---
 apiVersion: v1

--- a/chart/epinio/templates/ui/certificate.yaml
+++ b/chart/epinio/templates/ui/certificate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certManager.enabled }}
 {{- if and .Values.epinioUI.enabled .Values.epinioUI.ingress.enabled }}
 ---
 apiVersion: cert-manager.io/v1
@@ -12,4 +13,5 @@ spec:
     kind: ClusterIssuer
     name: {{ default .Values.global.tlsIssuer .Values.global.customTlsIssuer }}
   secretName: epinio-ui-tls
+{{- end }}
 {{- end }}

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -79,9 +79,6 @@ strategy:
     maxUnavailable: 1
 certManagerNamespace: cert-manager
 
-#  XXX eXperimental eXperimental eXperimental XXX
-## XXX  X            X            X           XXX
-##
 # Set enabled to false to disable cert manager.
 # With the auto-creation of secrets from Cert request gone the secrets have to specified manually.
 # See below. Leaving out the `ui` falls back to `epinio`. Same for `dex`. No other connections

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -78,6 +78,46 @@ strategy:
     maxSurge: 0
     maxUnavailable: 1
 certManagerNamespace: cert-manager
+
+#  XXX eXperimental eXperimental eXperimental XXX
+## XXX  X            X            X           XXX
+##
+# Set enabled to false to disable cert manager.
+# With the auto-creation of secrets from Cert request gone the secrets have to specified manually.
+# See below. Leaving out the `ui` falls back to `epinio`. Same for `dex`. No other connections
+# between them.
+# Further note:
+#  - s3 applies to either minio, or s3gw, whichever is active.
+#    In case of using an external s3 store it does not apply at all.
+#  - ui applies only when enabled
+#  - dex the same
+certManager:
+  enabled: true
+  registry:
+    cert: ""
+    key: ""
+    ca: ""
+  epinio:
+    cert: ""
+    key: ""
+    ca: ""
+  ui:
+    cert: ""
+    key: ""
+    ca: ""
+  dex:
+    cert: ""
+    key: ""
+    ca: ""
+  caRoot:
+    cert: ""
+    key: ""
+    ca: ""
+  s3:
+    cert: ""
+    key: ""
+    ca: ""
+
 # Connection details for the S3 storage
 s3:
   endpoint: s3.amazonaws.com
@@ -219,7 +259,7 @@ global:
   # Used in registry path when pushing -> "external.tld/apps/APPNAME"
   registryNamespace: "apps"
   # The name of the cluster issuer to use.
-  # Epinio creates three options: 'epinio-ca', 'selfsigned-issuer', 'letsencrypt-staging' and 'letsencrypt-production'.
+  # Epinio provides four options: 'epinio-ca', 'selfsigned-issuer', 'letsencrypt-staging' and 'letsencrypt-production'.
   tlsIssuer: "epinio-ca"
   # The name of your ClusterIssuer (it will override the tlsIssuer)
   customTlsIssuer: ""

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -109,10 +109,6 @@ certManager:
     cert: ""
     key: ""
     ca: ""
-  caRoot:
-    cert: ""
-    key: ""
-    ca: ""
   s3:
     cert: ""
     key: ""


### PR DESCRIPTION
Ref https://github.com/epinio/epinio/issues/2476
main PR: https://github.com/epinio/epinio/pull/2681

Enable disabling of CM `Certificate` resources.
Conversely inject `Secret` resources normally generated by CM.
Plus `values.yaml` parameters to configure these secrets.
