### PR TITLE
Update k3d base image to 5.7 and migrate to ghcr

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -8,7 +8,7 @@ RUN mv helm/*/helm /bin/helm
 
 
 ## Build the actual container
-FROM rancher/k3d:5.3
+FROM ghcr.io/k3d-io/k3d:5.7
 
 ARG VERSION
 ENV EPINIO_HELM_CHART_VERSION $VERSION


### PR DESCRIPTION
k3d has moved to ghcr.io/k3d-io instead of the Rancher dockerhub organization. This updates with that change and targets the latest minor of k3d.

Build was tested for the correct image path. Implementation has not yet been tested.